### PR TITLE
Add OULAD DbContext and models

### DIFF
--- a/OuladEtlEda/Models/Assessment.cs
+++ b/OuladEtlEda/Models/Assessment.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("assessments")]
+public class Assessment
+{
+    [Key]
+    public int IdAssessment { get; set; }
+
+    [ForeignKey(nameof(Course))]
+    public string CodeModule { get; set; } = null!;
+
+    [ForeignKey(nameof(Course))]
+    public string CodePresentation { get; set; } = null!;
+
+    public string? AssessmentType { get; set; }
+
+    public int? Date { get; set; }
+
+    public int Weight { get; set; }
+
+    public Course? Course { get; set; }
+    public ICollection<StudentAssessment> StudentAssessments { get; set; } = new List<StudentAssessment>();
+}

--- a/OuladEtlEda/Models/Course.cs
+++ b/OuladEtlEda/Models/Course.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("courses")]
+public class Course
+{
+    [Key]
+    [Column(Order = 0)]
+    public string CodeModule { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 1)]
+    public string CodePresentation { get; set; } = null!;
+
+    public int ModulePresentationLength { get; set; }
+
+    public ICollection<StudentInfo> Students { get; set; } = new List<StudentInfo>();
+    public ICollection<Assessment> Assessments { get; set; } = new List<Assessment>();
+    public ICollection<StudentRegistration> Registrations { get; set; } = new List<StudentRegistration>();
+    public ICollection<Vle> Vles { get; set; } = new List<Vle>();
+}

--- a/OuladEtlEda/Models/Enums.cs
+++ b/OuladEtlEda/Models/Enums.cs
@@ -1,0 +1,37 @@
+namespace OuladEtlEda.Models;
+
+public enum Gender
+{
+    Female = 0,
+    Male = 1
+}
+
+public enum AgeBand
+{
+    Under35 = 0,
+    From35To55 = 1,
+    Over55 = 2
+}
+
+public enum Disability
+{
+    No = 0,
+    Yes = 1
+}
+
+public enum FinalResult
+{
+    Withdrawn = 0,
+    Fail = 1,
+    Pass = 2,
+    Distinction = 3
+}
+
+public enum EducationLevel
+{
+    NoFormalQual = 0,
+    LowerThanAlevel = 1,
+    ALevelOrEquivalent = 2,
+    HEQualification = 3,
+    PostGraduate = 4
+}

--- a/OuladEtlEda/Models/StudentAssessment.cs
+++ b/OuladEtlEda/Models/StudentAssessment.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("studentAssessment")]
+public class StudentAssessment
+{
+    [Key]
+    [Column(Order = 0)]
+    [ForeignKey(nameof(Assessment))]
+    public int IdAssessment { get; set; }
+
+    [Key]
+    [Column(Order = 1)]
+    public int IdStudent { get; set; }
+
+    [Key]
+    [Column(Order = 2)]
+    public string CodeModule { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 3)]
+    public string CodePresentation { get; set; } = null!;
+
+    public int? DateSubmitted { get; set; }
+
+    public bool IsBanked { get; set; }
+
+    public float? Score { get; set; }
+
+    public Assessment? Assessment { get; set; }
+
+    [ForeignKey("CodeModule,CodePresentation,IdStudent")]
+    public StudentInfo? StudentInfo { get; set; }
+}

--- a/OuladEtlEda/Models/StudentInfo.cs
+++ b/OuladEtlEda/Models/StudentInfo.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("studentInfo")]
+public class StudentInfo
+{
+    [Key]
+    [Column(Order = 0)]
+    [ForeignKey(nameof(Course))]
+    public string CodeModule { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 1)]
+    [ForeignKey(nameof(Course))]
+    public string CodePresentation { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 2)]
+    public int IdStudent { get; set; }
+
+    public Gender Gender { get; set; }
+
+    public string? Region { get; set; }
+
+    public EducationLevel HighestEducation { get; set; }
+
+    public string? ImdBand { get; set; }
+
+    public AgeBand AgeBand { get; set; }
+
+    public int NumOfPrevAttempts { get; set; }
+
+    public int StudiedCredits { get; set; }
+
+    public Disability Disability { get; set; }
+
+    public FinalResult FinalResult { get; set; }
+
+    public Course? Course { get; set; }
+    public ICollection<StudentRegistration> Registrations { get; set; } = new List<StudentRegistration>();
+    public ICollection<StudentAssessment> Assessments { get; set; } = new List<StudentAssessment>();
+    public ICollection<StudentVle> StudentVles { get; set; } = new List<StudentVle>();
+}

--- a/OuladEtlEda/Models/StudentRegistration.cs
+++ b/OuladEtlEda/Models/StudentRegistration.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("studentRegistration")]
+public class StudentRegistration
+{
+    [Key]
+    [Column(Order = 0)]
+    [ForeignKey(nameof(Course))]
+    public string CodeModule { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 1)]
+    [ForeignKey(nameof(Course))]
+    public string CodePresentation { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 2)]
+    public int IdStudent { get; set; }
+
+    public int? DateRegistration { get; set; }
+
+    public int? DateUnregistration { get; set; }
+
+    public Course? Course { get; set; }
+
+    [ForeignKey("CodeModule,CodePresentation,IdStudent")]
+    public StudentInfo? StudentInfo { get; set; }
+}

--- a/OuladEtlEda/Models/StudentVle.cs
+++ b/OuladEtlEda/Models/StudentVle.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("studentVle")]
+public class StudentVle
+{
+    [Key]
+    [Column(Order = 0)]
+    [ForeignKey(nameof(Vle))]
+    public int IdSite { get; set; }
+
+    [Key]
+    [Column(Order = 1)]
+    public int IdStudent { get; set; }
+
+    [Key]
+    [Column(Order = 2)]
+    public string CodeModule { get; set; } = null!;
+
+    [Key]
+    [Column(Order = 3)]
+    public string CodePresentation { get; set; } = null!;
+
+    public int? Date { get; set; }
+
+    public int SumClick { get; set; }
+
+    public Vle? Vle { get; set; }
+
+    [ForeignKey("CodeModule,CodePresentation,IdStudent")]
+    public StudentInfo? StudentInfo { get; set; }
+}

--- a/OuladEtlEda/Models/Vle.cs
+++ b/OuladEtlEda/Models/Vle.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OuladEtlEda.Models;
+
+[Table("vle")]
+public class Vle
+{
+    [Key]
+    public int IdSite { get; set; }
+
+    [ForeignKey(nameof(Course))]
+    public string CodeModule { get; set; } = null!;
+
+    [ForeignKey(nameof(Course))]
+    public string CodePresentation { get; set; } = null!;
+
+    public string? ActivityType { get; set; }
+
+    public int? WeekFrom { get; set; }
+
+    public int? WeekTo { get; set; }
+
+    public Course? Course { get; set; }
+    public ICollection<StudentVle> StudentVles { get; set; } = new List<StudentVle>();
+}

--- a/OuladEtlEda/OuladContext.cs
+++ b/OuladEtlEda/OuladContext.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using OuladEtlEda.Models;
+
+namespace OuladEtlEda;
+
+public class OuladContext : DbContext
+{
+    public DbSet<Course> Courses => Set<Course>();
+    public DbSet<Assessment> Assessments => Set<Assessment>();
+    public DbSet<StudentAssessment> StudentAssessments => Set<StudentAssessment>();
+    public DbSet<StudentInfo> StudentInfos => Set<StudentInfo>();
+    public DbSet<StudentRegistration> StudentRegistrations => Set<StudentRegistration>();
+    public DbSet<Vle> Vles => Set<Vle>();
+    public DbSet<StudentVle> StudentVles => Set<StudentVle>();
+
+    public OuladContext(DbContextOptions<OuladContext> options) : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Course>().HasKey(c => new { c.CodeModule, c.CodePresentation });
+        modelBuilder.Entity<Assessment>().HasOne(a => a.Course)
+            .WithMany(c => c.Assessments)
+            .HasForeignKey(a => new { a.CodeModule, a.CodePresentation });
+
+        modelBuilder.Entity<Vle>().HasOne(v => v.Course)
+            .WithMany(c => c.Vles)
+            .HasForeignKey(v => new { v.CodeModule, v.CodePresentation });
+
+        modelBuilder.Entity<StudentInfo>().HasKey(s => new { s.CodeModule, s.CodePresentation, s.IdStudent });
+        modelBuilder.Entity<StudentInfo>().HasOne(s => s.Course)
+            .WithMany(c => c.Students)
+            .HasForeignKey(s => new { s.CodeModule, s.CodePresentation });
+
+        modelBuilder.Entity<StudentRegistration>().HasKey(r => new { r.CodeModule, r.CodePresentation, r.IdStudent });
+        modelBuilder.Entity<StudentRegistration>().HasOne(r => r.Course)
+            .WithMany(c => c.Registrations)
+            .HasForeignKey(r => new { r.CodeModule, r.CodePresentation });
+        modelBuilder.Entity<StudentRegistration>().HasOne(r => r.StudentInfo)
+            .WithMany(s => s.Registrations)
+            .HasForeignKey(r => new { r.CodeModule, r.CodePresentation, r.IdStudent });
+
+        modelBuilder.Entity<StudentAssessment>().HasKey(sa => new { sa.IdAssessment, sa.IdStudent, sa.CodeModule, sa.CodePresentation });
+        modelBuilder.Entity<StudentAssessment>().HasOne(sa => sa.Assessment)
+            .WithMany(a => a.StudentAssessments)
+            .HasForeignKey(sa => sa.IdAssessment);
+        modelBuilder.Entity<StudentAssessment>().HasOne(sa => sa.StudentInfo)
+            .WithMany(si => si.Assessments)
+            .HasForeignKey(sa => new { sa.CodeModule, sa.CodePresentation, sa.IdStudent });
+
+        modelBuilder.Entity<StudentVle>().HasKey(sv => new { sv.IdSite, sv.IdStudent, sv.CodeModule, sv.CodePresentation });
+        modelBuilder.Entity<StudentVle>().HasOne(sv => sv.Vle)
+            .WithMany(v => v.StudentVles)
+            .HasForeignKey(sv => sv.IdSite);
+        modelBuilder.Entity<StudentVle>().HasOne(sv => sv.StudentInfo)
+            .WithMany(si => si.StudentVles)
+            .HasForeignKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdStudent });
+
+        // store enums as integers
+        modelBuilder.Entity<StudentInfo>().Property(s => s.Gender).HasConversion<int>();
+        modelBuilder.Entity<StudentInfo>().Property(s => s.AgeBand).HasConversion<int>();
+        modelBuilder.Entity<StudentInfo>().Property(s => s.Disability).HasConversion<int>();
+        modelBuilder.Entity<StudentInfo>().Property(s => s.FinalResult).HasConversion<int>();
+        modelBuilder.Entity<StudentInfo>().Property(s => s.HighestEducation).HasConversion<int>();
+    }
+}

--- a/OuladEtlEda/Program.cs
+++ b/OuladEtlEda/Program.cs
@@ -1,2 +1,9 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using Microsoft.EntityFrameworkCore;
+using OuladEtlEda;
+
+var options = new DbContextOptionsBuilder<OuladContext>()
+    .UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Oulad;Trusted_Connection=True;")
+    .Options;
+
+using var db = new OuladContext(options);
+Console.WriteLine("Context configured.");

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ packages are referenced in `OuladEtlEda.csproj`:
 Microsoft.EntityFrameworkCore
 Microsoft.EntityFrameworkCore.SqlServer
 ```
+
+## Generating the Schema
+
+The `OuladContext` class defines the tables from the OULAD dataset. To generate
+the schema in a database run the standard EF Core commands:
+
+```bash
+dotnet ef migrations add InitialCreate
+dotnet ef database update
+```


### PR DESCRIPTION
## Summary
- define enum types for OULAD categorical columns
- add model classes for each dataset table
- configure `OuladContext` with relationships and enum conversions
- update Program to instantiate the context
- document schema generation using EF Core

## Testing
- `dotnet build OuladEtlEda/OuladEtlEda.csproj -v:q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462237e4c4832e91c5598422e99ed0