### PR TITLE
Add design time factory for EF Core

### DIFF
--- a/OuladEtlEda/OuladContextFactory.cs
+++ b/OuladEtlEda/OuladContextFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace OuladEtlEda;
+
+public class OuladContextFactory : IDesignTimeDbContextFactory<OuladContext>
+{
+    public OuladContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<OuladContext>()
+            .UseSqlServer("Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
+            .Options;
+
+        return new OuladContext(options);
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure a design-time `DbContext` factory

## Testing
- `which dotnet` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6846249ffe48832e95bbca453b01db6f