### PR TITLE
Fix EF Core cascade errors

### DIFF
--- a/OuladEtlEda/Models/Assessment.cs
+++ b/OuladEtlEda/Models/Assessment.cs
@@ -9,8 +9,10 @@ public class Assessment
     [Key]
     public int IdAssessment { get; set; }
 
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     public string? AssessmentType { get; set; }

--- a/OuladEtlEda/Models/Course.cs
+++ b/OuladEtlEda/Models/Course.cs
@@ -8,10 +8,12 @@ public class Course
 {
     [Key]
     [Column(Order = 0)]
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
     [Column(Order = 1)]
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     public int ModulePresentationLength { get; set; }

--- a/OuladEtlEda/Models/StudentAssessment.cs
+++ b/OuladEtlEda/Models/StudentAssessment.cs
@@ -17,10 +17,12 @@ public class StudentAssessment
 
     [Key]
     [Column(Order = 2)]
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
     [Column(Order = 3)]
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     public int? DateSubmitted { get; set; }

--- a/OuladEtlEda/Models/StudentInfo.cs
+++ b/OuladEtlEda/Models/StudentInfo.cs
@@ -8,10 +8,12 @@ public class StudentInfo
 {
     [Key]
     [Column(Order = 0)]
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
     [Column(Order = 1)]
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     [Key]

--- a/OuladEtlEda/Models/StudentRegistration.cs
+++ b/OuladEtlEda/Models/StudentRegistration.cs
@@ -8,10 +8,12 @@ public class StudentRegistration
 {
     [Key]
     [Column(Order = 0)]
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
     [Column(Order = 1)]
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     [Key]

--- a/OuladEtlEda/Models/StudentVle.cs
+++ b/OuladEtlEda/Models/StudentVle.cs
@@ -17,10 +17,12 @@ public class StudentVle
 
     [Key]
     [Column(Order = 2)]
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
     [Column(Order = 3)]
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     public int? Date { get; set; }

--- a/OuladEtlEda/Models/Vle.cs
+++ b/OuladEtlEda/Models/Vle.cs
@@ -9,8 +9,10 @@ public class Vle
     [Key]
     public int IdSite { get; set; }
 
+    [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
+    [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 
     public string? ActivityType { get; set; }

--- a/OuladEtlEda/OuladContext.cs
+++ b/OuladEtlEda/OuladContext.cs
@@ -46,10 +46,12 @@ public class OuladContext : DbContext
         modelBuilder.Entity<StudentAssessment>().HasKey(sa => new { sa.IdAssessment, sa.IdStudent, sa.CodeModule, sa.CodePresentation });
         modelBuilder.Entity<StudentAssessment>().HasOne(sa => sa.Assessment)
             .WithMany(a => a.StudentAssessments)
-            .HasForeignKey(sa => sa.IdAssessment);
+            .HasForeignKey(sa => sa.IdAssessment)
+            .OnDelete(DeleteBehavior.Restrict);
         modelBuilder.Entity<StudentAssessment>().HasOne(sa => sa.StudentInfo)
             .WithMany(si => si.Assessments)
-            .HasForeignKey(sa => new { sa.CodeModule, sa.CodePresentation, sa.IdStudent });
+            .HasForeignKey(sa => new { sa.CodeModule, sa.CodePresentation, sa.IdStudent })
+            .OnDelete(DeleteBehavior.Restrict);
 
         modelBuilder.Entity<StudentVle>().HasKey(sv => new { sv.IdSite, sv.IdStudent, sv.CodeModule, sv.CodePresentation });
         modelBuilder.Entity<StudentVle>().HasOne(sv => sv.Vle)


### PR DESCRIPTION
## Summary
- add length limits on key string properties
- restrict cascade delete for `StudentAssessment` relations

## Testing
- `dotnet build OuladEtlEda/OuladEtlEda.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462b7d73e0832ea31c88f804d87092