### PR TITLE
Add Serilog logging configuration

### DIFF
--- a/logging.json
+++ b/logging.json
@@ -1,0 +1,14 @@
+{
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/log.txt",
+          "rollingInterval": "Day"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- create `logging.json` with a basic configuration for Serilog
  - minimum level: Information
  - daily rolling file sink

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463580598c832e9eba841d2e4a067a