### PR TITLE
Add bulk loading and domain validation utilities

### DIFF
--- a/OuladEtlEda/AssessDomainValidator.cs
+++ b/OuladEtlEda/AssessDomainValidator.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using OuladEtlEda.Models;
+
+namespace OuladEtlEda;
+
+/// <summary>
+/// Domain validator for <see cref="Assessment"/> entities.
+/// </summary>
+public class AssessDomainValidator : IDomainValidator<Assessment>
+{
+    public Task ValidateAsync(Assessment entity)
+    {
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new ArgumentException("CodeModule is required", nameof(entity));
+
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new ArgumentException("CodePresentation is required", nameof(entity));
+
+        if (entity.Weight < 0)
+            throw new ArgumentException("Weight cannot be negative", nameof(entity));
+
+        return Task.CompletedTask;
+    }
+}

--- a/OuladEtlEda/BulkLoader.cs
+++ b/OuladEtlEda/BulkLoader.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EFCore.BulkExtensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace OuladEtlEda;
+
+/// <summary>
+/// Provides helper methods for bulk inserting entities using EF Core BulkExtensions.
+/// </summary>
+public class BulkLoader
+{
+    /// <summary>
+    /// Performs a bulk insert of the provided entities.
+    /// </summary>
+    public async Task BulkInsertAsync<T>(DbContext context, IList<T> entities) where T : class
+    {
+        await context.BulkInsertAsync(entities);
+    }
+}

--- a/OuladEtlEda/CategoricalOrdinalMapper.cs
+++ b/OuladEtlEda/CategoricalOrdinalMapper.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace OuladEtlEda;
+
+/// <summary>
+/// Maps categorical string values to ordinal integers per column.
+/// </summary>
+public class CategoricalOrdinalMapper
+{
+    private readonly Dictionary<string, Dictionary<string, int>> _columns = new();
+
+    /// <summary>
+    /// Returns the ordinal value mapped to <paramref name="value"/> for the
+    /// given <paramref name="column"/>. If the mapping does not exist it will
+    /// be created.
+    /// </summary>
+    public int GetOrAdd(string column, string value)
+    {
+        if (!_columns.TryGetValue(column, out var mappings))
+        {
+            mappings = new Dictionary<string, int>();
+            _columns[column] = mappings;
+        }
+
+        if (!mappings.TryGetValue(value, out var ordinal))
+        {
+            ordinal = mappings.Count;
+            mappings[value] = ordinal;
+        }
+
+        return ordinal;
+    }
+}

--- a/OuladEtlEda/IDomainValidator.cs
+++ b/OuladEtlEda/IDomainValidator.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace OuladEtlEda;
+
+/// <summary>
+/// Validates domain entities.
+/// </summary>
+public interface IDomainValidator<T>
+{
+    /// <summary>
+    /// Validates the specified entity.
+    /// </summary>
+    Task ValidateAsync(T entity);
+}

--- a/OuladEtlEda/OuladEtlEda.csproj
+++ b/OuladEtlEda/OuladEtlEda.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="EFCore.BulkExtensions" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OuladEtlEda/Program.cs
+++ b/OuladEtlEda/Program.cs
@@ -1,10 +1,17 @@
 using Microsoft.EntityFrameworkCore;
-using OuladEtlEda;
 
-var options = new DbContextOptionsBuilder<OuladContext>()
-    .UseSqlServer(
-        "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
-    .Options;
+namespace OuladEtlEda;
 
-using var db = new OuladContext(options);
-Console.WriteLine("Context configured.");
+internal class Program
+{
+    private static void Main()
+    {
+        var options = new DbContextOptionsBuilder<OuladContext>()
+            .UseSqlServer(
+                "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
+            .Options;
+
+        using var db = new OuladContext(options);
+        Console.WriteLine("Context configured.");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CategoricalOrdinalMapper` for ordinal encoding
- add `IDomainValidator<T>` interface
- create `AssessDomainValidator` implementation
- add `BulkLoader` helper using EFCore.BulkExtensions
- reference EFCore.BulkExtensions
- clean up `Program.cs`

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68463857a1f4832e9105298322a0cbe2