### PR TITLE
Remove mandatory CSV directory argument

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -22,10 +22,8 @@ internal class Program
             .CreateLogger();
 
         var modeOption = new Option<string>("--mode", () => "etl", "Execution mode");
-        var csvDirOption = new Option<string>("--csv-dir", "C:\\csv")
-        {
-            IsRequired = true
-        };
+        var csvDirOption = new Option<string>("--csv-dir", () => "C:\\csv",
+            "Directory containing CSV files");
         var root = new RootCommand { modeOption, csvDirOption };
 
         root.SetHandler(async (mode, csvDir) =>


### PR DESCRIPTION
## Summary
- make `--csv-dir` option optional by giving it a default value

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464926b6bc832ebf64f813338e251c