### PR TITLE
Support decimal weights in assessments

### DIFF
--- a/src/DataImport/AssessmentCsv.cs
+++ b/src/DataImport/AssessmentCsv.cs
@@ -14,5 +14,5 @@ public class AssessmentCsv
 
     [Name("date")] public int? Date { get; set; }
 
-    [Name("weight")] public int Weight { get; set; }
+    [Name("weight")] public decimal Weight { get; set; }
 }

--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -20,7 +20,7 @@ public class Assessment
 
     public int? Date { get; set; }
 
-    public int Weight { get; set; }
+    public decimal Weight { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }

--- a/src/Migrations/20250609023225_InitialCreate.Designer.cs
+++ b/src/Migrations/20250609023225_InitialCreate.Designer.cs
@@ -50,8 +50,8 @@ namespace OuladEtlEda.Migrations
                     b.Property<int?>("Date")
                         .HasColumnType("int");
 
-                    b.Property<int>("Weight")
-                        .HasColumnType("int");
+                    b.Property<decimal>("Weight")
+                        .HasColumnType("decimal(5,2)");
 
                     b.HasKey("IdAssessment");
 

--- a/src/Migrations/20250609023225_InitialCreate.cs
+++ b/src/Migrations/20250609023225_InitialCreate.cs
@@ -33,7 +33,7 @@ namespace OuladEtlEda.Migrations
                     CodePresentation = table.Column<string>(type: "varchar(8)", unicode: false, maxLength: 8, nullable: false),
                     AssessmentType = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Date = table.Column<int>(type: "int", nullable: true),
-                    Weight = table.Column<int>(type: "int", nullable: false)
+                    Weight = table.Column<decimal>(type: "decimal(5,2)", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/Migrations/OuladContextModelSnapshot.cs
+++ b/src/Migrations/OuladContextModelSnapshot.cs
@@ -47,8 +47,8 @@ namespace OuladEtlEda.Migrations
                     b.Property<int?>("Date")
                         .HasColumnType("int");
 
-                    b.Property<int>("Weight")
-                        .HasColumnType("int");
+                    b.Property<decimal>("Weight")
+                        .HasColumnType("decimal(5,2)");
 
                     b.HasKey("IdAssessment");
 


### PR DESCRIPTION
## Summary
- allow decimal `Weight` when reading assessment CSVs
- update domain model and EF Core migrations for decimal weight column

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684649fbfb74832e8afc14157f708f33