### PR TITLE
Extend ETL to all OULAD tables and add basic EDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ APA, un resumen técnico de 250 palabras, capturas y enlaces al repositorio.
    ```bash
    dotnet run -- --mode etl --csv-dir <ruta-a-csv>
    ```
-6. Realiza el análisis exploratorio de datos con los scripts en C# que
-   encontrarás en `src/`.
+6. Para el análisis exploratorio ejecuta:
+   ```bash
+   dotnet run -- --mode eda
+   ```
 
 ## 📚 Referencias
 - [Entity Framework Core Docs](https://learn.microsoft.com/ef/)

--- a/src/DataImport/CourseCsv.cs
+++ b/src/DataImport/CourseCsv.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class CourseCsv
+{
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("module_presentation_length")] public int ModulePresentationLength { get; set; }
+}

--- a/src/DataImport/CsvCourseReader.cs
+++ b/src/DataImport/CsvCourseReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvCourseReader : CsvReaderBase<CourseCsv>
+{
+    public CsvCourseReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/CsvStudentAssessmentReader.cs
+++ b/src/DataImport/CsvStudentAssessmentReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvStudentAssessmentReader : CsvReaderBase<StudentAssessmentCsv>
+{
+    public CsvStudentAssessmentReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/CsvStudentInfoReader.cs
+++ b/src/DataImport/CsvStudentInfoReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvStudentInfoReader : CsvReaderBase<StudentInfoCsv>
+{
+    public CsvStudentInfoReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/CsvStudentRegistrationReader.cs
+++ b/src/DataImport/CsvStudentRegistrationReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvStudentRegistrationReader : CsvReaderBase<StudentRegistrationCsv>
+{
+    public CsvStudentRegistrationReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/CsvStudentVleReader.cs
+++ b/src/DataImport/CsvStudentVleReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvStudentVleReader : CsvReaderBase<StudentVleCsv>
+{
+    public CsvStudentVleReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/CsvVleReader.cs
+++ b/src/DataImport/CsvVleReader.cs
@@ -1,0 +1,10 @@
+using CsvHelper.Configuration;
+
+namespace OuladEtlEda.DataImport;
+
+public class CsvVleReader : CsvReaderBase<VleCsv>
+{
+    public CsvVleReader(string path, CsvConfiguration? configuration = null) : base(path, configuration)
+    {
+    }
+}

--- a/src/DataImport/StudentAssessmentCsv.cs
+++ b/src/DataImport/StudentAssessmentCsv.cs
@@ -1,0 +1,14 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class StudentAssessmentCsv
+{
+    [Name("id_assessment")] public int IdAssessment { get; set; }
+    [Name("id_student")] public int IdStudent { get; set; }
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("date_submitted")] public int? DateSubmitted { get; set; }
+    [Name("is_banked")] public bool IsBanked { get; set; }
+    [Name("score")] public float? Score { get; set; }
+}

--- a/src/DataImport/StudentInfoCsv.cs
+++ b/src/DataImport/StudentInfoCsv.cs
@@ -1,0 +1,19 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class StudentInfoCsv
+{
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("id_student")] public int IdStudent { get; set; }
+    [Name("gender")] public string Gender { get; set; } = null!;
+    [Name("region")] public string? Region { get; set; }
+    [Name("highest_education")] public string HighestEducation { get; set; } = null!;
+    [Name("imd_band")] public string? ImdBand { get; set; }
+    [Name("age_band")] public string AgeBand { get; set; } = null!;
+    [Name("num_of_prev_attempts")] public int NumOfPrevAttempts { get; set; }
+    [Name("studied_credits")] public int StudiedCredits { get; set; }
+    [Name("disability")] public string Disability { get; set; } = null!;
+    [Name("final_result")] public string FinalResult { get; set; } = null!;
+}

--- a/src/DataImport/StudentRegistrationCsv.cs
+++ b/src/DataImport/StudentRegistrationCsv.cs
@@ -1,0 +1,12 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class StudentRegistrationCsv
+{
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("id_student")] public int IdStudent { get; set; }
+    [Name("date_registration")] public int? DateRegistration { get; set; }
+    [Name("date_unregistration")] public int? DateUnregistration { get; set; }
+}

--- a/src/DataImport/StudentVleCsv.cs
+++ b/src/DataImport/StudentVleCsv.cs
@@ -1,0 +1,13 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class StudentVleCsv
+{
+    [Name("id_site")] public int IdSite { get; set; }
+    [Name("id_student")] public int IdStudent { get; set; }
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("date")] public int? Date { get; set; }
+    [Name("sum_click")] public int SumClick { get; set; }
+}

--- a/src/DataImport/VleCsv.cs
+++ b/src/DataImport/VleCsv.cs
@@ -1,0 +1,13 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace OuladEtlEda.DataImport;
+
+public class VleCsv
+{
+    [Name("id_site")] public int IdSite { get; set; }
+    [Name("code_module")] public string CodeModule { get; set; } = null!;
+    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
+    [Name("activity_type")] public string? ActivityType { get; set; }
+    [Name("week_from")] public int? WeekFrom { get; set; }
+    [Name("week_to")] public int? WeekTo { get; set; }
+}

--- a/src/Domain/Validators/CourseValidator.cs
+++ b/src/Domain/Validators/CourseValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class CourseValidator : IDomainValidator<Course>
+{
+    public Task ValidateAsync(Course entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/StudentAssessmentValidator.cs
+++ b/src/Domain/Validators/StudentAssessmentValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class StudentAssessmentValidator : IDomainValidator<StudentAssessment>
+{
+    public Task ValidateAsync(StudentAssessment entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/StudentInfoValidator.cs
+++ b/src/Domain/Validators/StudentInfoValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class StudentInfoValidator : IDomainValidator<StudentInfo>
+{
+    public Task ValidateAsync(StudentInfo entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/StudentRegistrationValidator.cs
+++ b/src/Domain/Validators/StudentRegistrationValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class StudentRegistrationValidator : IDomainValidator<StudentRegistration>
+{
+    public Task ValidateAsync(StudentRegistration entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/StudentVleValidator.cs
+++ b/src/Domain/Validators/StudentVleValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class StudentVleValidator : IDomainValidator<StudentVle>
+{
+    public Task ValidateAsync(StudentVle entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/VleValidator.cs
+++ b/src/Domain/Validators/VleValidator.cs
@@ -1,0 +1,15 @@
+namespace OuladEtlEda.Domain.Validators;
+
+public class VleValidator : IDomainValidator<Vle>
+{
+    public Task ValidateAsync(Vle entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Eda/BasicEda.cs
+++ b/src/Eda/BasicEda.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using OuladEtlEda.DataAccess;
+
+namespace OuladEtlEda.Eda;
+
+public static class BasicEda
+{
+    public static void Run(OuladContext context)
+    {
+        var studentCount = context.StudentInfos.Count();
+        var courseCount = context.Courses.Count();
+        Console.WriteLine($"Students: {studentCount}");
+        Console.WriteLine($"Courses: {courseCount}");
+
+        var results = context.StudentInfos
+            .GroupBy(s => s.FinalResult)
+            .Select(g => new { Result = g.Key, Count = g.Count() })
+            .ToList();
+        Console.WriteLine("\nFinal results distribution:");
+        foreach (var r in results)
+            Console.WriteLine($"{r.Result}: {r.Count}");
+    }
+}

--- a/src/Pipeline/EtlPipeline.cs
+++ b/src/Pipeline/EtlPipeline.cs
@@ -11,18 +11,56 @@ public class EtlPipeline
     private readonly OuladContext _context;
     private readonly BulkLoader _loader;
     private readonly CategoricalOrdinalMapper _mapper;
-    private readonly CsvAssessmentReader _reader;
-    private readonly AssessmentValidator _validator;
+    private readonly CsvCourseReader _courseReader;
+    private readonly CsvAssessmentReader _assessmentReader;
+    private readonly CsvStudentInfoReader _studentInfoReader;
+    private readonly CsvStudentRegistrationReader _registrationReader;
+    private readonly CsvStudentAssessmentReader _studentAssessmentReader;
+    private readonly CsvVleReader _vleReader;
+    private readonly CsvStudentVleReader _studentVleReader;
 
-    public EtlPipeline(CsvAssessmentReader reader,
+    private readonly CourseValidator _courseValidator;
+    private readonly AssessmentValidator _assessmentValidator;
+    private readonly StudentInfoValidator _studentInfoValidator;
+    private readonly StudentRegistrationValidator _registrationValidator;
+    private readonly StudentAssessmentValidator _studentAssessmentValidator;
+    private readonly VleValidator _vleValidator;
+    private readonly StudentVleValidator _studentVleValidator;
+
+    public EtlPipeline(
+        CsvCourseReader courseReader,
+        CsvAssessmentReader assessmentReader,
+        CsvStudentInfoReader studentInfoReader,
+        CsvStudentRegistrationReader registrationReader,
+        CsvStudentAssessmentReader studentAssessmentReader,
+        CsvVleReader vleReader,
+        CsvStudentVleReader studentVleReader,
         CategoricalOrdinalMapper mapper,
-        AssessmentValidator validator,
+        CourseValidator courseValidator,
+        AssessmentValidator assessmentValidator,
+        StudentInfoValidator studentInfoValidator,
+        StudentRegistrationValidator registrationValidator,
+        StudentAssessmentValidator studentAssessmentValidator,
+        VleValidator vleValidator,
+        StudentVleValidator studentVleValidator,
         BulkLoader loader,
         OuladContext context)
     {
-        _reader = reader;
+        _courseReader = courseReader;
+        _assessmentReader = assessmentReader;
+        _studentInfoReader = studentInfoReader;
+        _registrationReader = registrationReader;
+        _studentAssessmentReader = studentAssessmentReader;
+        _vleReader = vleReader;
+        _studentVleReader = studentVleReader;
         _mapper = mapper;
-        _validator = validator;
+        _courseValidator = courseValidator;
+        _assessmentValidator = assessmentValidator;
+        _studentInfoValidator = studentInfoValidator;
+        _registrationValidator = registrationValidator;
+        _studentAssessmentValidator = studentAssessmentValidator;
+        _vleValidator = vleValidator;
+        _studentVleValidator = studentVleValidator;
         _loader = loader;
         _context = context;
     }
@@ -31,15 +69,13 @@ public class EtlPipeline
     {
         try
         {
-            var entities = new List<Assessment>();
-            await foreach (var csv in _reader.ReadAsync())
-            {
-                var assessment = Map(csv);
-                await _validator.ValidateAsync(assessment);
-                entities.Add(assessment);
-            }
-
-            await _loader.BulkInsertAsync(_context, entities);
+            await LoadCoursesAsync();
+            await LoadAssessmentsAsync();
+            await LoadStudentInfoAsync();
+            await LoadRegistrationsAsync();
+            await LoadStudentAssessmentsAsync();
+            await LoadVleAsync();
+            await LoadStudentVleAsync();
         }
         catch (DomainException ex)
         {
@@ -47,17 +83,180 @@ public class EtlPipeline
         }
     }
 
-    private Assessment Map(AssessmentCsv csv)
+    private async Task LoadCoursesAsync()
     {
-        var id = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString());
-        return new Assessment
+        var entities = new List<Course>();
+        await foreach (var csv in _courseReader.ReadAsync())
         {
-            IdAssessment = id,
-            CodeModule = csv.CodeModule,
-            CodePresentation = csv.CodePresentation,
-            AssessmentType = csv.AssessmentType,
-            Date = csv.Date,
-            Weight = csv.Weight
-        };
+            var entity = new Course
+            {
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                ModulePresentationLength = csv.ModulePresentationLength
+            };
+            await _courseValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private async Task LoadAssessmentsAsync()
+    {
+        var entities = new List<Assessment>();
+        await foreach (var csv in _assessmentReader.ReadAsync())
+        {
+            var entity = new Assessment
+            {
+                IdAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString()),
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                AssessmentType = csv.AssessmentType,
+                Date = csv.Date,
+                Weight = csv.Weight
+            };
+            await _assessmentValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private static Gender ParseGender(string value) => value.Trim().ToUpper() switch
+    {
+        "M" => Gender.Male,
+        "F" => Gender.Female,
+        _ => Enum.TryParse<Gender>(value, true, out var g) ? g : Gender.Female
+    };
+
+    private static AgeBand ParseAgeBand(string value) => value.Trim() switch
+    {
+        "0-35" => AgeBand.Under35,
+        "35-55" => AgeBand.From35To55,
+        _ => AgeBand.Over55
+    };
+
+    private static Disability ParseDisability(string value) => value.Trim().ToUpper() switch
+    {
+        "N" => Disability.No,
+        "Y" => Disability.Yes,
+        _ => Disability.No
+    };
+
+    private static FinalResult ParseFinalResult(string value) => Enum.TryParse<FinalResult>(value.Replace(" ", ""), true, out var r) ? r : FinalResult.Fail;
+
+    private static EducationLevel ParseEducation(string value)
+    {
+        var v = value.ToLower();
+        if (v.StartsWith("no formal")) return EducationLevel.NoFormalQual;
+        if (v.StartsWith("lower")) return EducationLevel.LowerThanAlevel;
+        if (v.StartsWith("a level")) return EducationLevel.ALevelOrEquivalent;
+        if (v.StartsWith("he")) return EducationLevel.HEQualification;
+        if (v.StartsWith("post")) return EducationLevel.PostGraduate;
+        return EducationLevel.NoFormalQual;
+    }
+
+    private async Task LoadStudentInfoAsync()
+    {
+        var entities = new List<StudentInfo>();
+        await foreach (var csv in _studentInfoReader.ReadAsync())
+        {
+            var entity = new StudentInfo
+            {
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                IdStudent = csv.IdStudent,
+                Gender = ParseGender(csv.Gender),
+                Region = csv.Region,
+                HighestEducation = ParseEducation(csv.HighestEducation),
+                ImdBand = csv.ImdBand,
+                AgeBand = ParseAgeBand(csv.AgeBand),
+                NumOfPrevAttempts = csv.NumOfPrevAttempts,
+                StudiedCredits = csv.StudiedCredits,
+                Disability = ParseDisability(csv.Disability),
+                FinalResult = ParseFinalResult(csv.FinalResult)
+            };
+            await _studentInfoValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private async Task LoadRegistrationsAsync()
+    {
+        var entities = new List<StudentRegistration>();
+        await foreach (var csv in _registrationReader.ReadAsync())
+        {
+            var entity = new StudentRegistration
+            {
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                IdStudent = csv.IdStudent,
+                DateRegistration = csv.DateRegistration,
+                DateUnregistration = csv.DateUnregistration
+            };
+            await _registrationValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private async Task LoadStudentAssessmentsAsync()
+    {
+        var entities = new List<StudentAssessment>();
+        await foreach (var csv in _studentAssessmentReader.ReadAsync())
+        {
+            var entity = new StudentAssessment
+            {
+                IdAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString()),
+                IdStudent = csv.IdStudent,
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                DateSubmitted = csv.DateSubmitted,
+                IsBanked = csv.IsBanked,
+                Score = csv.Score
+            };
+            await _studentAssessmentValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private async Task LoadVleAsync()
+    {
+        var entities = new List<Vle>();
+        await foreach (var csv in _vleReader.ReadAsync())
+        {
+            var entity = new Vle
+            {
+                IdSite = csv.IdSite,
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                ActivityType = csv.ActivityType,
+                WeekFrom = csv.WeekFrom,
+                WeekTo = csv.WeekTo
+            };
+            await _vleValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
+    }
+
+    private async Task LoadStudentVleAsync()
+    {
+        var entities = new List<StudentVle>();
+        await foreach (var csv in _studentVleReader.ReadAsync())
+        {
+            var entity = new StudentVle
+            {
+                IdSite = csv.IdSite,
+                IdStudent = csv.IdStudent,
+                CodeModule = csv.CodeModule,
+                CodePresentation = csv.CodePresentation,
+                Date = csv.Date,
+                SumClick = csv.SumClick
+            };
+            await _studentVleValidator.ValidateAsync(entity);
+            entities.Add(entity);
+        }
+        await _loader.BulkInsertAsync(_context, entities);
     }
 }


### PR DESCRIPTION
## Summary
- implement CSV readers for the remaining OULAD tables
- add validators for all domain entities
- rewrite `EtlPipeline` to load every table
- wire up the new pipeline in `Program.cs`
- add a simple EDA module
- document EDA usage in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846decdef3c832ebc8acbc01cb4b484