### PR TITLE
Refactor validators and model builder

### DIFF
--- a/src/DataAccess/ModelBuilderExtensions.cs
+++ b/src/DataAccess/ModelBuilderExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OuladEtlEda.Domain;
+
+namespace OuladEtlEda.DataAccess;
+
+public static class ModelBuilderExtensions
+{
+    public static void ConfigureCourseEntity<TEntity>(this EntityTypeBuilder<TEntity> entity)
+        where TEntity : class, ICourseEntity
+    {
+        entity.Property(e => e.CodeModule)
+            .HasMaxLength(8)
+            .IsUnicode(false);
+        entity.Property(e => e.CodePresentation)
+            .HasMaxLength(8)
+            .IsUnicode(false);
+    }
+}

--- a/src/DataAccess/OuladContext.cs
+++ b/src/DataAccess/OuladContext.cs
@@ -24,21 +24,11 @@ public class OuladContext : DbContext
         modelBuilder.Entity<Course>(entity =>
         {
             entity.HasKey(c => new { c.CodeModule, c.CodePresentation });
-            entity.Property(c => c.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(c => c.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
         });
         modelBuilder.Entity<Assessment>(entity =>
         {
-            entity.Property(a => a.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(a => a.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(a => a.Course)
                 .WithMany(c => c.Assessments)
                 .HasForeignKey(a => new { a.CodeModule, a.CodePresentation })
@@ -46,12 +36,7 @@ public class OuladContext : DbContext
         });
         modelBuilder.Entity<Vle>(entity =>
         {
-            entity.Property(v => v.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(v => v.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(v => v.Course)
                 .WithMany(c => c.Vles)
                 .HasForeignKey(v => new { v.CodeModule, v.CodePresentation })
@@ -61,12 +46,7 @@ public class OuladContext : DbContext
         modelBuilder.Entity<StudentInfo>(entity =>
         {
             entity.HasKey(s => new { s.CodeModule, s.CodePresentation, s.IdStudent });
-            entity.Property(s => s.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(s => s.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(s => s.Course)
                 .WithMany(c => c.Students)
                 .HasForeignKey(s => new { s.CodeModule, s.CodePresentation })
@@ -76,12 +56,7 @@ public class OuladContext : DbContext
         modelBuilder.Entity<StudentRegistration>(entity =>
         {
             entity.HasKey(r => new { r.CodeModule, r.CodePresentation, r.IdStudent });
-            entity.Property(r => r.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(r => r.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(r => r.Course)
                 .WithMany(c => c.Registrations)
                 .HasForeignKey(r => new { r.CodeModule, r.CodePresentation })
@@ -95,12 +70,7 @@ public class OuladContext : DbContext
         modelBuilder.Entity<StudentAssessment>(entity =>
         {
             entity.HasKey(sa => new { sa.IdAssessment, sa.IdStudent, sa.CodeModule, sa.CodePresentation });
-            entity.Property(sa => sa.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(sa => sa.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(sa => sa.Assessment)
                 .WithMany(a => a.StudentAssessments)
                 .HasForeignKey(sa => sa.IdAssessment)
@@ -114,12 +84,7 @@ public class OuladContext : DbContext
         modelBuilder.Entity<StudentVle>(entity =>
         {
             entity.HasKey(sv => new { sv.IdSite, sv.IdStudent, sv.CodeModule, sv.CodePresentation });
-            entity.Property(sv => sv.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(sv => sv.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
+            entity.ConfigureCourseEntity();
             entity.HasOne(sv => sv.Vle)
                 .WithMany(v => v.StudentVles)
                 .HasForeignKey(sv => sv.IdSite)
@@ -128,16 +93,6 @@ public class OuladContext : DbContext
                 .WithMany(si => si.StudentVles)
                 .HasForeignKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdStudent })
                 .OnDelete(DeleteBehavior.Restrict);
-        });
-
-        modelBuilder.Entity<Vle>(entity =>
-        {
-            entity.Property(v => v.CodeModule)
-                .HasMaxLength(8)
-                .IsUnicode(false);
-            entity.Property(v => v.CodePresentation)
-                .HasMaxLength(8)
-                .IsUnicode(false);
         });
 
         // store enums as integers

--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("assessments")]
-public class Assessment
+public class Assessment : ICourseEntity
 {
     [Key] public int IdAssessment { get; set; }
 

--- a/src/Domain/Course.cs
+++ b/src/Domain/Course.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("courses")]
-public class Course
+public class Course : ICourseEntity
 {
     [Key]
     [Column(Order = 0, TypeName = "varchar(8)")]

--- a/src/Domain/ICourseEntity.cs
+++ b/src/Domain/ICourseEntity.cs
@@ -1,0 +1,7 @@
+namespace OuladEtlEda.Domain;
+
+public interface ICourseEntity
+{
+    string CodeModule { get; }
+    string CodePresentation { get; }
+}

--- a/src/Domain/StudentAssessment.cs
+++ b/src/Domain/StudentAssessment.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("studentAssessment")]
-public class StudentAssessment
+public class StudentAssessment : ICourseEntity
 {
     [Key]
     [Column(Order = 0)]

--- a/src/Domain/StudentInfo.cs
+++ b/src/Domain/StudentInfo.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("studentInfo")]
-public class StudentInfo
+public class StudentInfo : ICourseEntity
 {
     [Key]
     [Column(Order = 0, TypeName = "varchar(8)")]

--- a/src/Domain/StudentRegistration.cs
+++ b/src/Domain/StudentRegistration.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("studentRegistration")]
-public class StudentRegistration
+public class StudentRegistration : ICourseEntity
 {
     [Key]
     [Column(Order = 0, TypeName = "varchar(8)")]

--- a/src/Domain/StudentVle.cs
+++ b/src/Domain/StudentVle.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("studentVle")]
-public class StudentVle
+public class StudentVle : ICourseEntity
 {
     [Key]
     [Column(Order = 0)]

--- a/src/Domain/Validators/AssessmentValidator.cs
+++ b/src/Domain/Validators/AssessmentValidator.cs
@@ -2,22 +2,13 @@ using OuladEtlEda.Domain;
 
 namespace OuladEtlEda.Domain.Validators;
 
-public class AssessmentValidator : IDomainValidator<Assessment>
+public class AssessmentValidator : CourseEntityValidator<Assessment>
 {
-    public Task ValidateAsync(Assessment entity)
+    public override async Task ValidateAsync(Assessment entity)
     {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
+        await base.ValidateAsync(entity);
 
         if (entity.Weight < 0)
             throw new DomainException("Weight cannot be negative");
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Domain/Validators/CourseEntityValidator.cs
+++ b/src/Domain/Validators/CourseEntityValidator.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace OuladEtlEda.Domain.Validators;
+
+public class CourseEntityValidator<T> : IDomainValidator<T> where T : ICourseEntity
+{
+    public virtual Task ValidateAsync(T entity)
+    {
+        if (entity == null)
+            throw new DomainException("Entity cannot be null");
+        if (string.IsNullOrWhiteSpace(entity.CodeModule))
+            throw new DomainException("CodeModule is required");
+        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
+            throw new DomainException("CodePresentation is required");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Domain/Validators/CourseValidator.cs
+++ b/src/Domain/Validators/CourseValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class CourseValidator : IDomainValidator<Course>
+public class CourseValidator : CourseEntityValidator<Course>
 {
-    public Task ValidateAsync(Course entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Validators/StudentAssessmentValidator.cs
+++ b/src/Domain/Validators/StudentAssessmentValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class StudentAssessmentValidator : IDomainValidator<StudentAssessment>
+public class StudentAssessmentValidator : CourseEntityValidator<StudentAssessment>
 {
-    public Task ValidateAsync(StudentAssessment entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Validators/StudentInfoValidator.cs
+++ b/src/Domain/Validators/StudentInfoValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class StudentInfoValidator : IDomainValidator<StudentInfo>
+public class StudentInfoValidator : CourseEntityValidator<StudentInfo>
 {
-    public Task ValidateAsync(StudentInfo entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Validators/StudentRegistrationValidator.cs
+++ b/src/Domain/Validators/StudentRegistrationValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class StudentRegistrationValidator : IDomainValidator<StudentRegistration>
+public class StudentRegistrationValidator : CourseEntityValidator<StudentRegistration>
 {
-    public Task ValidateAsync(StudentRegistration entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Validators/StudentVleValidator.cs
+++ b/src/Domain/Validators/StudentVleValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class StudentVleValidator : IDomainValidator<StudentVle>
+public class StudentVleValidator : CourseEntityValidator<StudentVle>
 {
-    public Task ValidateAsync(StudentVle entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Validators/VleValidator.cs
+++ b/src/Domain/Validators/VleValidator.cs
@@ -1,15 +1,7 @@
 namespace OuladEtlEda.Domain.Validators;
 
-public class VleValidator : IDomainValidator<Vle>
+public class VleValidator : CourseEntityValidator<Vle>
 {
-    public Task ValidateAsync(Vle entity)
-    {
-        if (entity == null)
-            throw new DomainException("Entity cannot be null");
-        if (string.IsNullOrWhiteSpace(entity.CodeModule))
-            throw new DomainException("CodeModule is required");
-        if (string.IsNullOrWhiteSpace(entity.CodePresentation))
-            throw new DomainException("CodePresentation is required");
-        return Task.CompletedTask;
-    }
+    // inherits base behavior
 }
+

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace OuladEtlEda.Domain;
 
 [Table("vle")]
-public class Vle
+public class Vle : ICourseEntity
 {
     [Key] public int IdSite { get; set; }
 

--- a/src/Infrastructure/ConnectionStrings.cs
+++ b/src/Infrastructure/ConnectionStrings.cs
@@ -1,0 +1,7 @@
+namespace OuladEtlEda.Infrastructure;
+
+public static class ConnectionStrings
+{
+    public const string Default =
+        "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False";
+}

--- a/src/Infrastructure/OuladContextFactory.cs
+++ b/src/Infrastructure/OuladContextFactory.cs
@@ -9,8 +9,7 @@ public class OuladContextFactory : IDesignTimeDbContextFactory<OuladContext>
     public OuladContext CreateDbContext(string[] args)
     {
         var options = new DbContextOptionsBuilder<OuladContext>()
-            .UseSqlServer(
-                "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
+            .UseSqlServer(ConnectionStrings.Default)
             .Options;
 
         return new OuladContext(options);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -32,8 +32,7 @@ internal class Program
             Log.Information("Execution mode: {Mode}", mode);
 
             var options = new DbContextOptionsBuilder<OuladContext>()
-                .UseSqlServer(
-                    "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False")
+                .UseSqlServer(ConnectionStrings.Default)
                 .Options;
 
             using var context = new OuladContext(options);


### PR DESCRIPTION
## Summary
- extract connection string constant
- add ICourseEntity interface and CourseEntityValidator
- centralize code & presentation config via ModelBuilderExtensions
- update validators and db context to use helpers

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `dotnet build src/OuladEtlEda.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2527b84832ea45423e2250d8c5c