### PR TITLE
Move connection string into configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ FodyWeavers.xsd
 /src/anonymisedData/studentRegistration.csv
 /src/anonymisedData/studentVle.csv
 /src/anonymisedData/vle.csv
+
+# Local configuration
+/appsettings.json

--- a/appsettings.sample.json
+++ b/appsettings.sample.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "Default": "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False"
+  }
+}

--- a/src/Infrastructure/ConnectionStrings.cs
+++ b/src/Infrastructure/ConnectionStrings.cs
@@ -1,7 +1,13 @@
+using Microsoft.Extensions.Configuration;
+
 namespace OuladEtlEda.Infrastructure;
 
 public static class ConnectionStrings
 {
-    public const string Default =
-        "Data Source=BLANQUITOH-SERV;User ID=Blanquitoh;Password=welc0me;Database=Oulad;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False";
+    private static readonly IConfigurationRoot Config = new ConfigurationBuilder()
+        .AddJsonFile("appsettings.json", optional: true)
+        .AddJsonFile("appsettings.sample.json", optional: true)
+        .Build();
+
+    public static string Default => Config.GetConnectionString("Default")!;
 }


### PR DESCRIPTION
## Summary
- load connection string from `appsettings.json`
- provide `appsettings.sample.json` with example values
- ignore local `appsettings.json`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e590ca08832eb3f7ea0899e19555