### PR TITLE
Add ordinal code fields and mapping

### DIFF
--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -18,6 +18,8 @@ public class Assessment : ICourseEntity
 
     public string? AssessmentType { get; set; }
 
+    public int? AssessmentTypeOrdinal { get; set; }
+
     public int? Date { get; set; }
 
     public decimal Weight { get; set; }

--- a/src/Domain/StudentInfo.cs
+++ b/src/Domain/StudentInfo.cs
@@ -22,9 +22,13 @@ public class StudentInfo : ICourseEntity
 
     public string? Region { get; set; }
 
+    public int? RegionOrdinal { get; set; }
+
     public EducationLevel HighestEducation { get; set; }
 
     public string? ImdBand { get; set; }
+
+    public int? ImdBandOrdinal { get; set; }
 
     public AgeBand AgeBand { get; set; }
 

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -18,6 +18,8 @@ public class Vle : ICourseEntity
 
     public string? ActivityType { get; set; }
 
+    public int? ActivityTypeOrdinal { get; set; }
+
     public int? WeekFrom { get; set; }
 
     public int? WeekTo { get; set; }

--- a/src/Migrations/20250609120000_AddOrdinalColumns.cs
+++ b/src/Migrations/20250609120000_AddOrdinalColumns.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OuladEtlEda.Migrations;
+
+/// <inheritdoc />
+public partial class AddOrdinalColumns : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int?>(
+            name: "AssessmentTypeOrdinal",
+            table: "assessments",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int?>(
+            name: "RegionOrdinal",
+            table: "studentInfo",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int?>(
+            name: "ImdBandOrdinal",
+            table: "studentInfo",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int?>(
+            name: "ActivityTypeOrdinal",
+            table: "vle",
+            type: "int",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "AssessmentTypeOrdinal",
+            table: "assessments");
+
+        migrationBuilder.DropColumn(
+            name: "RegionOrdinal",
+            table: "studentInfo");
+
+        migrationBuilder.DropColumn(
+            name: "ImdBandOrdinal",
+            table: "studentInfo");
+
+        migrationBuilder.DropColumn(
+            name: "ActivityTypeOrdinal",
+            table: "vle");
+    }
+}
+

--- a/src/Migrations/OuladContextModelSnapshot.cs
+++ b/src/Migrations/OuladContextModelSnapshot.cs
@@ -32,6 +32,9 @@ namespace OuladEtlEda.Migrations
                     b.Property<string>("AssessmentType")
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<int?>("AssessmentTypeOrdinal")
+                        .HasColumnType("int");
+
                     b.Property<string>("CodeModule")
                         .IsRequired()
                         .HasMaxLength(8)
@@ -153,11 +156,17 @@ namespace OuladEtlEda.Migrations
                     b.Property<string>("ImdBand")
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<int?>("ImdBandOrdinal")
+                        .HasColumnType("int");
+
                     b.Property<int>("NumOfPrevAttempts")
                         .HasColumnType("int");
 
                     b.Property<string>("Region")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int?>("RegionOrdinal")
+                        .HasColumnType("int");
 
                     b.Property<int>("StudiedCredits")
                         .HasColumnType("int");
@@ -241,6 +250,9 @@ namespace OuladEtlEda.Migrations
 
                     b.Property<string>("ActivityType")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int?>("ActivityTypeOrdinal")
+                        .HasColumnType("int");
 
                     b.Property<string>("CodeModule")
                         .IsRequired()

--- a/src/Pipeline/EtlPipeline.cs
+++ b/src/Pipeline/EtlPipeline.cs
@@ -133,6 +133,9 @@ public class EtlPipeline
                 CodeModule = csv.CodeModule,
                 CodePresentation = csv.CodePresentation,
                 AssessmentType = csv.AssessmentType,
+                AssessmentTypeOrdinal = csv.AssessmentType == null
+                    ? null
+                    : _mapper.GetOrAdd("assessment_type", csv.AssessmentType),
                 Date = csv.Date,
                 Weight = csv.Weight
             },
@@ -182,8 +185,14 @@ public class EtlPipeline
                 IdStudent = csv.IdStudent,
                 Gender = ParseGender(csv.Gender),
                 Region = csv.Region,
+                RegionOrdinal = csv.Region == null
+                    ? null
+                    : _mapper.GetOrAdd("region", csv.Region),
                 HighestEducation = ParseEducation(csv.HighestEducation),
                 ImdBand = csv.ImdBand,
+                ImdBandOrdinal = csv.ImdBand == null
+                    ? null
+                    : _mapper.GetOrAdd("imd_band", csv.ImdBand),
                 AgeBand = ParseAgeBand(csv.AgeBand),
                 NumOfPrevAttempts = csv.NumOfPrevAttempts,
                 StudiedCredits = csv.StudiedCredits,
@@ -229,6 +238,9 @@ public class EtlPipeline
                 CodeModule = csv.CodeModule,
                 CodePresentation = csv.CodePresentation,
                 ActivityType = csv.ActivityType,
+                ActivityTypeOrdinal = csv.ActivityType == null
+                    ? null
+                    : _mapper.GetOrAdd("activity_type", csv.ActivityType),
                 WeekFrom = csv.WeekFrom,
                 WeekTo = csv.WeekTo
             },

--- a/tests/MapperTests/CategoricalOrdinalMapperTests.cs
+++ b/tests/MapperTests/CategoricalOrdinalMapperTests.cs
@@ -13,4 +13,23 @@ public class CategoricalOrdinalMapperTests
         var id2 = mapper.GetOrAdd("col", "A");
         Assert.Equal(id1, id2);
     }
+
+    [Fact]
+    public void Different_value_returns_incremented_id()
+    {
+        var mapper = new CategoricalOrdinalMapper();
+        var id1 = mapper.GetOrAdd("col", "A");
+        var id2 = mapper.GetOrAdd("col", "B");
+        Assert.Equal(id1 + 1, id2);
+    }
+
+    [Fact]
+    public void Same_value_in_different_columns_independent()
+    {
+        var mapper = new CategoricalOrdinalMapper();
+        var id1 = mapper.GetOrAdd("col1", "A");
+        var id2 = mapper.GetOrAdd("col2", "A");
+        Assert.Equal(0, id1);
+        Assert.Equal(0, id2);
+    }
 }


### PR DESCRIPTION
## Summary
- support ordinal codes in Assessment, StudentInfo and Vle entities
- map categorical values to integers in `EtlPipeline`
- migrate database schema to include ordinal columns
- extend mapper unit tests for ordinal behaviour

## Testing
- `./test.sh` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684704a55cec832eb9876087ea3fbd1c