### PR TITLE
Fix switch statement handling for ETL mode

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -55,7 +55,7 @@ internal class Program
 
             switch (mode)
             {
-
+                case ExecutionMode.Etl:
                     var courseReader = new CsvReader<CourseCsv>(Path.Combine(csvDir, "courses.csv"));
                     var assessmentReader = new CsvReader<AssessmentCsv>(Path.Combine(csvDir, "assessments.csv"));
                     var studentInfoReader = new CsvReader<StudentInfoCsv>(Path.Combine(csvDir, "studentInfo.csv"));


### PR DESCRIPTION
## Summary
- add missing `ExecutionMode.Etl` case in `Program.cs`

## Testing
- `./test.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684717fbd3dc832eb28b060548ac2885