### PR TITLE
Improve setup instructions for .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,26 @@ APA, un resumen técnico de 250 palabras, capturas y enlaces al repositorio.
 
 ## 🚀 Cómo ejecutar el proyecto
 1. Clona este repositorio.
-2. Ejecuta `dotnet restore` en la raíz para descargar las dependencias.
-3. Crea la base de datos destino y ajusta la cadena de conexión en `Program.cs`.
-4. Ejecuta `dotnet ef database update` para generar el esquema. Este comando
+2. Ejecuta `./setup.sh` para instalar el SDK de .NET si aún no está disponible.
+3. Ejecuta `dotnet restore` en la raíz para descargar las dependencias.
+4. Crea la base de datos destino y ajusta la cadena de conexión en `Program.cs`.
+5. Ejecuta `dotnet ef database update` para generar el esquema. Este comando
    también aplica la migración `CreateFullDomainView` que genera la vista
    `FullDomain` consolidando las tablas **ASSESS** y **VLE**.
    Si prefieres ejecutarla manualmente puedes correr:
    ```bash
    sqlcmd -S <server> -d <db> -i sql/create_full_domain.sql
    ```
-5. Corre la aplicación en modo ETL:
+6. Corre la aplicación en modo ETL:
    ```bash
    dotnet run -- --mode Etl --csv-dir <ruta-a-csv>
    ```
-6. Para el análisis exploratorio ejecuta:
+7. Para el análisis exploratorio ejecuta:
    ```bash
    dotnet run -- --mode Eda
    ```
    Las gráficas generadas por `ExtendedEda` se guardarán en la carpeta `plots`.
-7. Ejecuta `./test.sh` para construir y correr todas las pruebas.
+8. Ejecuta `./test.sh` para construir y correr todas las pruebas.
 
 ## 📚 Referencias
 - [Entity Framework Core Docs](https://learn.microsoft.com/ef/)

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+
+if command -v dotnet >/dev/null; then
+    echo "dotnet SDK ya está instalado"
+    exit 0
+fi
+
 wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+
+if ! command -v dotnet >/dev/null; then
+    echo "dotnet SDK no encontrado. Ejecuta ./setup.sh primero." >&2
+    exit 1
+fi
+
 dotnet restore
 dotnet build
 dotnet test


### PR DESCRIPTION
## Summary
- mention running `setup.sh` before `dotnet restore`
- prevent duplicate installation in `setup.sh`
- make `test.sh` check for `dotnet` and hint to run setup

## Testing
- `./test.sh` *(fails: dotnet SDK no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68472205ff3c832e85f9a8ae31808687