### PR TITLE
Fix missing OxyPlot types

### DIFF
--- a/src/OuladEtlEda.csproj
+++ b/src/OuladEtlEda.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="OxyPlot" Version="2.2.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add main `OxyPlot` package so types such as `ColumnSeries` and `ColumnItem` are resolved

## Testing
- `./test.sh` *(fails: dotnet SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684727017cdc832ea507fb808cce6492