### PR TITLE
Fix ETL pipeline concurrency and extract mapping

### DIFF
--- a/src/Pipeline/Mappers/AssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/AssessmentCsvMapper.cs
@@ -1,0 +1,28 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+using OuladEtlEda.Pipeline;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class AssessmentCsvMapper : ICsvEntityMapper<AssessmentCsv, Assessment>
+{
+    private readonly CategoricalOrdinalMapper _mapper;
+
+    public AssessmentCsvMapper(CategoricalOrdinalMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+    public Assessment Map(AssessmentCsv csv) => new()
+    {
+        IdAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString()),
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        AssessmentType = csv.AssessmentType,
+        AssessmentTypeOrdinal = csv.AssessmentType == null
+            ? null
+            : _mapper.GetOrAdd("assessment_type", csv.AssessmentType),
+        Date = csv.Date,
+        Weight = csv.Weight
+    };
+}

--- a/src/Pipeline/Mappers/CourseCsvMapper.cs
+++ b/src/Pipeline/Mappers/CourseCsvMapper.cs
@@ -1,0 +1,14 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class CourseCsvMapper : ICsvEntityMapper<CourseCsv, Course>
+{
+    public Course Map(CourseCsv csv) => new()
+    {
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        ModulePresentationLength = csv.ModulePresentationLength
+    };
+}

--- a/src/Pipeline/Mappers/ICsvEntityMapper.cs
+++ b/src/Pipeline/Mappers/ICsvEntityMapper.cs
@@ -1,0 +1,6 @@
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public interface ICsvEntityMapper<TCsv, TEntity>
+{
+    TEntity Map(TCsv csv);
+}

--- a/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
@@ -1,0 +1,26 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+using OuladEtlEda.Pipeline;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class StudentAssessmentCsvMapper : ICsvEntityMapper<StudentAssessmentCsv, StudentAssessment>
+{
+    private readonly CategoricalOrdinalMapper _mapper;
+
+    public StudentAssessmentCsvMapper(CategoricalOrdinalMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+    public StudentAssessment Map(StudentAssessmentCsv csv) => new()
+    {
+        IdAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString()),
+        IdStudent = csv.IdStudent,
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        DateSubmitted = csv.DateSubmitted,
+        IsBanked = csv.IsBanked,
+        Score = csv.Score
+    };
+}

--- a/src/Pipeline/Mappers/StudentInfoCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentInfoCsvMapper.cs
@@ -1,0 +1,68 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+using OuladEtlEda.Pipeline;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class StudentInfoCsvMapper : ICsvEntityMapper<StudentInfoCsv, StudentInfo>
+{
+    private readonly CategoricalOrdinalMapper _mapper;
+
+    public StudentInfoCsvMapper(CategoricalOrdinalMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+    public StudentInfo Map(StudentInfoCsv csv) => new()
+    {
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        IdStudent = csv.IdStudent,
+        Gender = ParseGender(csv.Gender),
+        Region = csv.Region,
+        RegionOrdinal = csv.Region == null ? null : _mapper.GetOrAdd("region", csv.Region),
+        HighestEducation = ParseEducation(csv.HighestEducation),
+        ImdBand = csv.ImdBand,
+        ImdBandOrdinal = csv.ImdBand == null ? null : _mapper.GetOrAdd("imd_band", csv.ImdBand),
+        AgeBand = ParseAgeBand(csv.AgeBand),
+        NumOfPrevAttempts = csv.NumOfPrevAttempts,
+        StudiedCredits = csv.StudiedCredits,
+        Disability = ParseDisability(csv.Disability),
+        FinalResult = ParseFinalResult(csv.FinalResult)
+    };
+
+    private static Gender ParseGender(string value) => value.Trim().ToUpper() switch
+    {
+        "M" => Gender.Male,
+        "F" => Gender.Female,
+        _ => Enum.TryParse<Gender>(value, true, out var g) ? g : Gender.Female
+    };
+
+    private static AgeBand ParseAgeBand(string value) => value.Trim() switch
+    {
+        "0-35" => AgeBand.Under35,
+        "35-55" => AgeBand.From35To55,
+        _ => AgeBand.Over55
+    };
+
+    private static Disability ParseDisability(string value) => value.Trim().ToUpper() switch
+    {
+        "N" => Disability.No,
+        "Y" => Disability.Yes,
+        _ => Disability.No
+    };
+
+    private static FinalResult ParseFinalResult(string value) =>
+        Enum.TryParse<FinalResult>(value.Replace(" ", string.Empty), true, out var r) ? r : FinalResult.Fail;
+
+    private static EducationLevel ParseEducation(string value)
+    {
+        var v = value.ToLower();
+        if (v.StartsWith("no formal")) return EducationLevel.NoFormalQual;
+        if (v.StartsWith("lower")) return EducationLevel.LowerThanAlevel;
+        if (v.StartsWith("a level")) return EducationLevel.ALevelOrEquivalent;
+        if (v.StartsWith("he")) return EducationLevel.HEQualification;
+        if (v.StartsWith("post")) return EducationLevel.PostGraduate;
+        return EducationLevel.NoFormalQual;
+    }
+}

--- a/src/Pipeline/Mappers/StudentRegistrationCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentRegistrationCsvMapper.cs
@@ -1,0 +1,16 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class StudentRegistrationCsvMapper : ICsvEntityMapper<StudentRegistrationCsv, StudentRegistration>
+{
+    public StudentRegistration Map(StudentRegistrationCsv csv) => new()
+    {
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        IdStudent = csv.IdStudent,
+        DateRegistration = csv.DateRegistration,
+        DateUnregistration = csv.DateUnregistration
+    };
+}

--- a/src/Pipeline/Mappers/StudentVleCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentVleCsvMapper.cs
@@ -1,0 +1,17 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class StudentVleCsvMapper : ICsvEntityMapper<StudentVleCsv, StudentVle>
+{
+    public StudentVle Map(StudentVleCsv csv) => new()
+    {
+        IdSite = csv.IdSite,
+        IdStudent = csv.IdStudent,
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        Date = csv.Date,
+        SumClick = csv.SumClick
+    };
+}

--- a/src/Pipeline/Mappers/VleCsvMapper.cs
+++ b/src/Pipeline/Mappers/VleCsvMapper.cs
@@ -1,0 +1,26 @@
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+using OuladEtlEda.Pipeline;
+
+namespace OuladEtlEda.Pipeline.Mappers;
+
+public class VleCsvMapper : ICsvEntityMapper<VleCsv, Vle>
+{
+    private readonly CategoricalOrdinalMapper _mapper;
+
+    public VleCsvMapper(CategoricalOrdinalMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+    public Vle Map(VleCsv csv) => new()
+    {
+        IdSite = csv.IdSite,
+        CodeModule = csv.CodeModule,
+        CodePresentation = csv.CodePresentation,
+        ActivityType = csv.ActivityType,
+        ActivityTypeOrdinal = csv.ActivityType == null ? null : _mapper.GetOrAdd("activity_type", csv.ActivityType),
+        WeekFrom = csv.WeekFrom,
+        WeekTo = csv.WeekTo
+    };
+}


### PR DESCRIPTION
## Summary
- execute ETL load steps sequentially instead of concurrently
- move CSV-to-entity mapping logic into dedicated mapper classes
- update ETL pipeline to use the new mappers

## Testing
- `./test.sh` *(fails: `dotnet SDK no encontrado. Ejecuta ./setup.sh primero.`)*

------
https://chatgpt.com/codex/tasks/task_e_68472c057de0832ea4b8b579afb44698