### PR TITLE
Lookup StudentAssessment codes from Assessments

### DIFF
--- a/src/DataImport/Models/StudentAssessmentCsv.cs
+++ b/src/DataImport/Models/StudentAssessmentCsv.cs
@@ -6,8 +6,6 @@ public class StudentAssessmentCsv
 {
     [Name("id_assessment")] public int IdAssessment { get; set; }
     [Name("id_student")] public int IdStudent { get; set; }
-    [Name("code_module")] public string CodeModule { get; set; } = null!;
-    [Name("code_presentation")] public string CodePresentation { get; set; } = null!;
     [Name("date_submitted")] public int? DateSubmitted { get; set; }
     [Name("is_banked")] public bool IsBanked { get; set; }
     [Name("score")] public float? Score { get; set; }

--- a/src/Pipeline/EtlPipeline.cs
+++ b/src/Pipeline/EtlPipeline.cs
@@ -80,7 +80,7 @@ public class EtlPipeline
         _assessmentMapper = new AssessmentCsvMapper(mapper);
         _studentInfoMapper = new StudentInfoCsvMapper(mapper);
         _registrationMapper = new StudentRegistrationCsvMapper();
-        _studentAssessmentMapper = new StudentAssessmentCsvMapper(mapper);
+        _studentAssessmentMapper = new StudentAssessmentCsvMapper(mapper, context);
         _vleMapper = new VleCsvMapper(mapper);
         _studentVleMapper = new StudentVleCsvMapper();
     }

--- a/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using OuladEtlEda.DataAccess;
 using OuladEtlEda.DataImport.Models;
 using OuladEtlEda.Domain;
 
@@ -6,20 +8,27 @@ namespace OuladEtlEda.Pipeline.Mappers;
 public class StudentAssessmentCsvMapper : ICsvEntityMapper<StudentAssessmentCsv, StudentAssessment>
 {
     private readonly CategoricalOrdinalMapper _mapper;
+    private readonly OuladContext _context;
 
-    public StudentAssessmentCsvMapper(CategoricalOrdinalMapper mapper)
+    public StudentAssessmentCsvMapper(CategoricalOrdinalMapper mapper, OuladContext context)
     {
         _mapper = mapper;
+        _context = context;
     }
 
     public StudentAssessment Map(StudentAssessmentCsv csv)
     {
+        var idAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString());
+        var assessment = _context.Assessments.AsNoTracking().FirstOrDefault(a => a.IdAssessment == idAssessment);
+        if (assessment == null)
+            throw new InvalidOperationException($"Assessment {csv.IdAssessment} not found");
+
         return new StudentAssessment
         {
-            IdAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString()),
+            IdAssessment = idAssessment,
             IdStudent = csv.IdStudent,
-            CodeModule = csv.CodeModule,
-            CodePresentation = csv.CodePresentation,
+            CodeModule = assessment.CodeModule,
+            CodePresentation = assessment.CodePresentation,
             DateSubmitted = csv.DateSubmitted,
             IsBanked = csv.IsBanked,
             Score = csv.Score

--- a/tests/MapperTests/StudentAssessmentCsvMapperTests.cs
+++ b/tests/MapperTests/StudentAssessmentCsvMapperTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using OuladEtlEda.DataAccess;
+using OuladEtlEda.DataImport.Models;
+using OuladEtlEda.Domain;
+using OuladEtlEda.Pipeline;
+using OuladEtlEda.Pipeline.Mappers;
+using Xunit;
+
+namespace OuladEtlEda.Tests.MapperTests;
+
+public class StudentAssessmentCsvMapperTests
+{
+    [Fact]
+    public void Mapper_resolves_module_and_presentation_from_assessment()
+    {
+        var options = new DbContextOptionsBuilder<OuladContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var context = new OuladContext(options);
+
+        var mapper = new CategoricalOrdinalMapper();
+        var assessmentId = mapper.GetOrAdd("assessment_id", "1");
+        context.Assessments.Add(new Assessment
+        {
+            IdAssessment = assessmentId,
+            CodeModule = "AAA",
+            CodePresentation = "2021"
+        });
+        context.SaveChanges();
+
+        var csvMapper = new StudentAssessmentCsvMapper(mapper, context);
+        var csv = new StudentAssessmentCsv
+        {
+            IdAssessment = 1,
+            IdStudent = 7,
+            DateSubmitted = 5,
+            IsBanked = false,
+            Score = 75
+        };
+
+        var result = csvMapper.Map(csv);
+
+        Assert.Equal("AAA", result.CodeModule);
+        Assert.Equal("2021", result.CodePresentation);
+    }
+}


### PR DESCRIPTION
## Summary
- update `StudentAssessmentCsv` to remove course code fields
- map module and presentation in `StudentAssessmentCsvMapper` using loaded `Assessments`
- give `EtlPipeline`'s mapper access to the context for lookup
- test mapper resolves course data from assessment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476ccaeeac832ea848cbb123f79a77