### PR TITLE
Fix truncation error when clearing tables

### DIFF
--- a/src/Pipeline/EtlPipeline.cs
+++ b/src/Pipeline/EtlPipeline.cs
@@ -155,7 +155,7 @@ public class EtlPipeline
 
         foreach (var table in tables)
         {
-            await _context.Database.ExecuteSqlRawAsync($"TRUNCATE TABLE [{table}]");
+            await _context.Database.ExecuteSqlRawAsync($"DELETE FROM [{table}];");
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid using `TRUNCATE TABLE` on tables with foreign keys

## Testing
- `./test.sh` *(fails: `dotnet` SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684770cd68a4832eb2d1d3f07e24b1e1