### PR TITLE
Handle missing assessments gracefully

### DIFF
--- a/src/Pipeline/EtlPipeline.cs
+++ b/src/Pipeline/EtlPipeline.cs
@@ -97,6 +97,11 @@ public class EtlPipeline
         await foreach (var csv in reader.ReadAsync())
         {
             var entity = map(csv);
+            if (entity == null)
+            {
+                Log.Warning("Skipping record for {Entity} due to mapping failure", typeof(TEntity).Name);
+                continue;
+            }
             await validator.ValidateAsync(entity);
             entities.Add(entity);
             count++;

--- a/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using OuladEtlEda.DataAccess;
 using OuladEtlEda.DataImport.Models;
 using OuladEtlEda.Domain;
+using Serilog;
 
 namespace OuladEtlEda.Pipeline.Mappers;
 
@@ -16,12 +17,15 @@ public class StudentAssessmentCsvMapper : ICsvEntityMapper<StudentAssessmentCsv,
         _context = context;
     }
 
-    public StudentAssessment Map(StudentAssessmentCsv csv)
+    public StudentAssessment? Map(StudentAssessmentCsv csv)
     {
         var idAssessment = _mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString());
         var assessment = _context.Assessments.AsNoTracking().FirstOrDefault(a => a.IdAssessment == idAssessment);
         if (assessment == null)
-            throw new InvalidOperationException($"Assessment {csv.IdAssessment} not found");
+        {
+            Log.Warning("Assessment {AssessmentId} not found for student {StudentId}", csv.IdAssessment, csv.IdStudent);
+            return null;
+        }
 
         return new StudentAssessment
         {


### PR DESCRIPTION
## Summary
- log missing assessment IDs instead of throwing an exception
- skip records with missing assessments in the ETL pipeline

## Testing
- `./test.sh` *(fails: dotnet SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684772e61100832eba51a5bd50af57b8