### PR TITLE
Fix unlimited string warnings

### DIFF
--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -8,6 +8,8 @@ public class Assessment : ICourseEntity
 {
     [Key] public int IdAssessment { get; set; }
 
+    [MaxLength(20)]
+    [Column(TypeName = "varchar(20)")]
     public string? AssessmentType { get; set; }
 
     public int? AssessmentTypeOrdinal { get; set; }

--- a/src/Domain/StudentInfo.cs
+++ b/src/Domain/StudentInfo.cs
@@ -10,12 +10,16 @@ public class StudentInfo : ICourseEntity
 
     public Gender Gender { get; set; }
 
+    [MaxLength(32)]
+    [Column(TypeName = "varchar(32)")]
     public string? Region { get; set; }
 
     public int? RegionOrdinal { get; set; }
 
     public EducationLevel HighestEducation { get; set; }
 
+    [MaxLength(32)]
+    [Column(TypeName = "varchar(32)")]
     public string? ImdBand { get; set; }
 
     public int? ImdBandOrdinal { get; set; }

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -8,6 +8,8 @@ public class Vle : ICourseEntity
 {
     [Key] public int IdSite { get; set; }
 
+    [MaxLength(32)]
+    [Column(TypeName = "varchar(32)")]
     public string? ActivityType { get; set; }
 
     public int? ActivityTypeOrdinal { get; set; }


### PR DESCRIPTION
## Summary
- set maximum lengths for AssessmentType, Region, ImdBand, and ActivityType to avoid unlimited-length strings

## Testing
- `./test.sh` *(fails: dotnet SDK no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684774a7b6b4832eb513cb71016d55b7