### PR TITLE
Fix primary keys for course-based entities

### DIFF
--- a/src/DataAccess/OuladContext.cs
+++ b/src/DataAccess/OuladContext.cs
@@ -24,6 +24,7 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
         });
         modelBuilder.Entity<Assessment>(entity =>
         {
+            entity.HasKey(a => new { a.IdAssessment, a.CodeModule, a.CodePresentation });
             entity.ConfigureCourseEntity();
             entity.HasOne(a => a.Course)
                 .WithMany(c => c.Assessments)
@@ -32,6 +33,7 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
         });
         modelBuilder.Entity<Vle>(entity =>
         {
+            entity.HasKey(v => new { v.IdSite, v.CodeModule, v.CodePresentation });
             entity.ConfigureCourseEntity();
             entity.HasOne(v => v.Course)
                 .WithMany(c => c.Vles)
@@ -69,7 +71,7 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
             entity.ConfigureCourseEntity();
             entity.HasOne(sa => sa.Assessment)
                 .WithMany(a => a.StudentAssessments)
-                .HasForeignKey(sa => sa.IdAssessment)
+                .HasForeignKey(sa => new { sa.IdAssessment, sa.CodeModule, sa.CodePresentation })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(sa => sa.StudentInfo)
                 .WithMany(si => si.Assessments)
@@ -79,11 +81,11 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
 
         modelBuilder.Entity<StudentVle>(entity =>
         {
-            entity.HasKey(sv => new { sv.IdSite, sv.IdStudent, sv.CodeModule, sv.CodePresentation });
+            entity.HasKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdStudent });
             entity.ConfigureCourseEntity();
             entity.HasOne(sv => sv.Vle)
                 .WithMany(v => v.StudentVles)
-                .HasForeignKey(sv => sv.IdSite)
+                .HasForeignKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdSite })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(sv => sv.StudentInfo)
                 .WithMany(si => si.StudentVles)

--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -6,7 +6,9 @@ namespace OuladEtlEda.Domain;
 [Table("assessments")]
 public class Assessment : ICourseEntity
 {
-    [Key] public int IdAssessment { get; set; }
+    [Key]
+    [Column(Order = 0)]
+    public int IdAssessment { get; set; }
 
     [MaxLength(20)]
     [Column(TypeName = "varchar(20)")]
@@ -23,11 +25,13 @@ public class Assessment : ICourseEntity
 
     public ICollection<StudentAssessment> StudentAssessments { get; set; } = new List<StudentAssessment>();
 
+    [Key]
+    [Column(Order = 1, TypeName = "varchar(8)")]
     [MaxLength(8)]
-    [Column(TypeName = "varchar(8)")]
     public string CodeModule { get; set; } = null!;
 
+    [Key]
+    [Column(Order = 2, TypeName = "varchar(8)")]
     [MaxLength(8)]
-    [Column(TypeName = "varchar(8)")]
     public string CodePresentation { get; set; } = null!;
 }

--- a/src/Domain/StudentAssessment.cs
+++ b/src/Domain/StudentAssessment.cs
@@ -8,7 +8,6 @@ public class StudentAssessment : ICourseEntity
 {
     [Key]
     [Column(Order = 0)]
-    [ForeignKey(nameof(Assessment))]
     public int IdAssessment { get; set; }
 
     [Key] [Column(Order = 1)] public int IdStudent { get; set; }
@@ -19,6 +18,7 @@ public class StudentAssessment : ICourseEntity
 
     public float? Score { get; set; }
 
+    [ForeignKey("IdAssessment,CodeModule,CodePresentation")]
     public Assessment? Assessment { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation,IdStudent")]

--- a/src/Domain/StudentVle.cs
+++ b/src/Domain/StudentVle.cs
@@ -6,29 +6,30 @@ namespace OuladEtlEda.Domain;
 [Table("studentVle")]
 public class StudentVle : ICourseEntity
 {
-    [Key]
-    [Column(Order = 0)]
-    [ForeignKey(nameof(Vle))]
+    [Column(Order = 3)]
     public int IdSite { get; set; }
 
-    [Key] [Column(Order = 1)] public int IdStudent { get; set; }
+    [Key]
+    [Column(Order = 2)]
+    public int IdStudent { get; set; }
 
     public int? Date { get; set; }
 
     public int SumClick { get; set; }
 
+    [ForeignKey("CodeModule,CodePresentation,IdSite")]
     public Vle? Vle { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation,IdStudent")]
     public StudentInfo? StudentInfo { get; set; }
 
     [Key]
-    [Column(Order = 2, TypeName = "varchar(8)")]
+    [Column(Order = 0, TypeName = "varchar(8)")]
     [MaxLength(8)]
     public string CodeModule { get; set; } = null!;
 
     [Key]
-    [Column(Order = 3, TypeName = "varchar(8)")]
+    [Column(Order = 1, TypeName = "varchar(8)")]
     [MaxLength(8)]
     public string CodePresentation { get; set; } = null!;
 }

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -6,7 +6,9 @@ namespace OuladEtlEda.Domain;
 [Table("vle")]
 public class Vle : ICourseEntity
 {
-    [Key] public int IdSite { get; set; }
+    [Key]
+    [Column(Order = 0)]
+    public int IdSite { get; set; }
 
     [MaxLength(32)]
     [Column(TypeName = "varchar(32)")]
@@ -23,11 +25,13 @@ public class Vle : ICourseEntity
 
     public ICollection<StudentVle> StudentVles { get; set; } = new List<StudentVle>();
 
+    [Key]
+    [Column(Order = 1, TypeName = "varchar(8)")]
     [MaxLength(8)]
-    [Column(TypeName = "varchar(8)")]
     public string CodeModule { get; set; } = null!;
 
+    [Key]
+    [Column(Order = 2, TypeName = "varchar(8)")]
     [MaxLength(8)]
-    [Column(TypeName = "varchar(8)")]
     public string CodePresentation { get; set; } = null!;
 }

--- a/src/sql/create_full_domain.sql
+++ b/src/sql/create_full_domain.sql
@@ -35,6 +35,8 @@ SELECT
     si.FinalResult
 FROM studentAssessment sa
 JOIN assessments a ON sa.IdAssessment = a.IdAssessment
+    AND sa.CodeModule = a.CodeModule
+    AND sa.CodePresentation = a.CodePresentation
 JOIN studentInfo si ON sa.CodeModule = si.CodeModule
     AND sa.CodePresentation = si.CodePresentation
     AND sa.IdStudent = si.IdStudent
@@ -71,6 +73,8 @@ SELECT
     si.FinalResult
 FROM studentVle sv
 JOIN vle v ON sv.IdSite = v.IdSite
+    AND sv.CodeModule = v.CodeModule
+    AND sv.CodePresentation = v.CodePresentation
 JOIN studentInfo si ON sv.CodeModule = si.CodeModule
     AND sv.CodePresentation = si.CodePresentation
     AND sv.IdStudent = si.IdStudent;


### PR DESCRIPTION
## Summary
- adjust assessment, VLE and student entities so course and presentation form part of their keys
- update EF Core configuration and foreign keys
- correct join conditions in `create_full_domain.sql`

## Testing
- `./test.sh` *(fails: dotnet SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684785dd77a4832eaab6ea2fcce4ca15