### PR TITLE
Fix order of foreign key properties

### DIFF
--- a/src/DataAccess/OuladContext.cs
+++ b/src/DataAccess/OuladContext.cs
@@ -85,7 +85,7 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
             entity.ConfigureCourseEntity();
             entity.HasOne(sv => sv.Vle)
                 .WithMany(v => v.StudentVles)
-                .HasForeignKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdSite })
+                .HasForeignKey(sv => new { sv.IdSite, sv.CodeModule, sv.CodePresentation })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(sv => sv.StudentInfo)
                 .WithMany(si => si.StudentVles)

--- a/src/Domain/StudentVle.cs
+++ b/src/Domain/StudentVle.cs
@@ -17,7 +17,7 @@ public class StudentVle : ICourseEntity
 
     public int SumClick { get; set; }
 
-    [ForeignKey("CodeModule,CodePresentation,IdSite")]
+    [ForeignKey("IdSite,CodeModule,CodePresentation")]
     public Vle? Vle { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation,IdStudent")]


### PR DESCRIPTION
## Summary
- align `StudentVle` navigation key order with `Vle` primary key
- update EF configuration accordingly

## Testing
- `./test.sh` *(fails: dotnet SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68478812ad10832eb119738ff905b551