### PR TITLE
Optimize student assessment mapping

### DIFF
--- a/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/StudentAssessmentCsvMapper.cs
@@ -1,19 +1,19 @@
-using Microsoft.EntityFrameworkCore;
-using OuladEtlEda.DataAccess;
+using System.Collections.Generic;
 using OuladEtlEda.DataImport.Models;
 using OuladEtlEda.Domain;
 using Serilog;
 
 namespace OuladEtlEda.Pipeline.Mappers;
 
-public class StudentAssessmentCsvMapper(CategoricalOrdinalMapper mapper, OuladContext context)
+public class StudentAssessmentCsvMapper(
+    CategoricalOrdinalMapper mapper,
+    IReadOnlyDictionary<int, Assessment> assessments)
     : ICsvEntityMapper<StudentAssessmentCsv, StudentAssessment>
 {
     public StudentAssessment? Map(StudentAssessmentCsv csv)
     {
         var idAssessment = mapper.GetOrAdd("assessment_id", csv.IdAssessment.ToString());
-        var assessment = context.Assessments.AsNoTracking().FirstOrDefault(a => a.IdAssessment == idAssessment);
-        if (assessment != null)
+        if (assessments.TryGetValue(idAssessment, out var assessment))
             return new StudentAssessment
             {
                 IdAssessment = idAssessment,

--- a/tests/MapperTests/StudentAssessmentCsvMapperTests.cs
+++ b/tests/MapperTests/StudentAssessmentCsvMapperTests.cs
@@ -29,7 +29,10 @@ public class StudentAssessmentCsvMapperTests
         });
         context.SaveChanges();
 
-        var csvMapper = new StudentAssessmentCsvMapper(mapper, context);
+        var assessments = context.Assessments
+            .AsNoTracking()
+            .ToDictionary(a => a.IdAssessment);
+        var csvMapper = new StudentAssessmentCsvMapper(mapper, assessments);
         var csv = new StudentAssessmentCsv
         {
             IdAssessment = 1,


### PR DESCRIPTION
## Summary
- load assessments into a dictionary before mapping student assessments
- pass assessment lookup to `StudentAssessmentCsvMapper`
- instantiate `StudentAssessmentCsvMapper` after loading assessments
- update mapper unit test to use the lookup

## Testing
- `./test.sh` *(fails: `dotnet SDK no encontrado. Ejecuta ./setup.sh primero.`)*

------
https://chatgpt.com/codex/tasks/task_e_68478c2dc4b0832e8c4e9d67e07c8f71