### PR TITLE
Improve BulkLoader performance

### DIFF
--- a/src/Infrastructure/BulkLoader.cs
+++ b/src/Infrastructure/BulkLoader.cs
@@ -1,22 +1,46 @@
 using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
+using System.Linq.Expressions;
 
 namespace OuladEtlEda.Infrastructure;
 
 public class BulkLoader
 {
+    private static readonly Dictionary<Type, List<Delegate>> _getterCache = new();
+
+    private static Func<T, object?> BuildGetter<T>(string propertyName)
+    {
+        var param = Expression.Parameter(typeof(T), "e");
+        var property = Expression.Property(param, propertyName);
+        var convert = Expression.Convert(property, typeof(object));
+        return Expression.Lambda<Func<T, object?>>(convert, param).Compile();
+    }
+
     public async Task BulkInsertAsync<T>(DbContext context, IList<T> entities) where T : class
     {
         var entityType = context.Model.FindEntityType(typeof(T));
         var keyProps = entityType?.FindPrimaryKey()?.Properties;
+        List<Func<T, object?>> getters = new();
         if (keyProps != null && keyProps.Count > 0)
         {
+            lock (_getterCache)
+            {
+                if (!_getterCache.TryGetValue(typeof(T), out var cached))
+                {
+                    cached = keyProps
+                        .Select(p => (Delegate)BuildGetter<T>(p.Name))
+                        .ToList();
+                    _getterCache[typeof(T)] = cached;
+                }
+                getters = cached.Cast<Func<T, object?>>().ToList();
+            }
+
             var seen = new HashSet<string>();
             var deduped = new List<T>(entities.Count);
             foreach (var entity in entities)
             {
-                var key = string.Join('|', keyProps.Select(p => typeof(T).GetProperty(p.Name)!.GetValue(entity)?.ToString()));
+                var key = string.Join('|', getters.Select(g => g(entity)?.ToString()));
                 if (seen.Add(key))
                 {
                     deduped.Add(entity);


### PR DESCRIPTION
## Summary
- optimize duplicate checking in `BulkLoader`
- build and cache delegates for key retrieval using expressions

## Testing
- `./test.sh` *(fails: dotnet SDK no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68478d6fdfac832e8ed149a41489bb0e