### PR TITLE
Fix mapper compile errors by making date fields nullable

### DIFF
--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -16,7 +16,7 @@ public class Assessment : ICourseEntity
 
     public int? AssessmentTypeOrdinal { get; set; }
 
-    public int Date { get; set; }
+    public int? Date { get; set; }
 
     public decimal Weight { get; set; }
 

--- a/src/Domain/StudentAssessment.cs
+++ b/src/Domain/StudentAssessment.cs
@@ -12,7 +12,7 @@ public class StudentAssessment : ICourseEntity
 
     [Key] [Column(Order = 1)] public int IdStudent { get; set; }
 
-    public int DateSubmitted { get; set; }
+    public int? DateSubmitted { get; set; }
 
     public bool IsBanked { get; set; }
 

--- a/src/Domain/StudentRegistration.cs
+++ b/src/Domain/StudentRegistration.cs
@@ -8,9 +8,9 @@ public class StudentRegistration : ICourseEntity
 {
     [Key] [Column(Order = 2)] public int IdStudent { get; set; }
 
-    public int DateRegistration { get; set; }
+    public int? DateRegistration { get; set; }
 
-    public int DateUnregistration { get; set; }
+    public int? DateUnregistration { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }

--- a/src/Domain/StudentVle.cs
+++ b/src/Domain/StudentVle.cs
@@ -14,7 +14,7 @@ public class StudentVle : ICourseEntity
     [Column(Order = 1)]
     public int IdStudent { get; set; }
 
-    public int Date { get; set; }
+    public int? Date { get; set; }
 
     public int SumClick { get; set; }
 

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -14,11 +14,11 @@ public class Vle : ICourseEntity
     [Column(TypeName = "varchar(45)")]
     public string ActivityType { get; set; } = null!;
 
-    public int ActivityTypeOrdinal { get; set; }
+    public int? ActivityTypeOrdinal { get; set; }
 
-    public int WeekFrom { get; set; }
+    public int? WeekFrom { get; set; }
 
-    public int WeekTo { get; set; }
+    public int? WeekTo { get; set; }
 
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }


### PR DESCRIPTION
## Summary
- make nullable date properties in domain models so mappers accept `int?`

## Testing
- `./test.sh` *(fails: dotnet SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847949a1f40832e9580471ed6ac2804