### PR TITLE
Add assessment type enum

### DIFF
--- a/src/DataAccess/OuladContext.cs
+++ b/src/DataAccess/OuladContext.cs
@@ -99,5 +99,6 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
         modelBuilder.Entity<StudentInfo>().Property(s => s.Disability).HasConversion<int>();
         modelBuilder.Entity<StudentInfo>().Property(s => s.FinalResult).HasConversion<int>();
         modelBuilder.Entity<StudentInfo>().Property(s => s.HighestEducation).HasConversion<int>();
+        modelBuilder.Entity<Assessment>().Property(a => a.AssessmentTypeEnum).HasConversion<int>();
     }
 }

--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -14,6 +14,8 @@ public class Assessment : ICourseEntity
     [Column(TypeName = "varchar(20)")]
     public string AssessmentType { get; set; } = null!;
 
+    public AssessmentType AssessmentTypeEnum { get; set; }
+
     public int? AssessmentTypeOrdinal { get; set; }
 
     public int? Date { get; set; }

--- a/src/Domain/Enums.cs
+++ b/src/Domain/Enums.cs
@@ -35,3 +35,10 @@ public enum EducationLevel
     HEQualification = 3,
     PostGraduate = 4
 }
+
+public enum AssessmentType
+{
+    Tma = 0,
+    Cma = 1,
+    Exam = 2
+}

--- a/src/Domain/StudentRegistration.cs
+++ b/src/Domain/StudentRegistration.cs
@@ -19,7 +19,7 @@ public class StudentRegistration : ICourseEntity
     public StudentInfo? StudentInfo { get; set; }
 
     [Key]
-    [Column(Order = 0, TypeName = "varchar(45")]
+    [Column(Order = 0, TypeName = "varchar(45)")]
     [MaxLength(45)]
     public string CodeModule { get; set; } = null!;
 

--- a/src/Pipeline/Mappers/AssessmentCsvMapper.cs
+++ b/src/Pipeline/Mappers/AssessmentCsvMapper.cs
@@ -13,11 +13,22 @@ public class AssessmentCsvMapper(CategoricalOrdinalMapper mapper) : ICsvEntityMa
             CodeModule = csv.CodeModule,
             CodePresentation = csv.CodePresentation,
             AssessmentType = csv.AssessmentType,
+            AssessmentTypeEnum = ParseAssessmentType(csv.AssessmentType),
             AssessmentTypeOrdinal = csv.AssessmentType == null
                 ? null
                 : mapper.GetOrAdd("assessment_type", csv.AssessmentType),
             Date = csv.Date,
             Weight = csv.Weight
+        };
+    }
+
+    private static AssessmentType ParseAssessmentType(string? value)
+    {
+        return value?.Trim().ToUpper() switch
+        {
+            "TMA" => AssessmentType.Tma,
+            "CMA" => AssessmentType.Cma,
+            _ => AssessmentType.Exam
         };
     }
 }


### PR DESCRIPTION
## Summary
- add `AssessmentType` enum and store it on `Assessment`
- clean up the student registration column metadata
- add EF conversion for the new enumeration
- map assessment type strings to the enum

## Testing
- `./test.sh` *(fails: dotnet SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684795c4681c832e9826e1f0df6430a6