### PR TITLE
Fix missing keys for EF navigation

### DIFF
--- a/src/DataAccess/OuladContext.cs
+++ b/src/DataAccess/OuladContext.cs
@@ -56,11 +56,11 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
             entity.HasNoKey();
             entity.ConfigureCourseEntity();
             entity.HasOne(r => r.Course)
-                .WithMany(c => c.Registrations)
+                .WithMany()
                 .HasForeignKey(r => new { r.CodeModule, r.CodePresentation })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(r => r.StudentInfo)
-                .WithMany(s => s.Registrations)
+                .WithMany()
                 .HasForeignKey(r => new { r.CodeModule, r.CodePresentation, r.IdStudent })
                 .OnDelete(DeleteBehavior.Restrict);
         });
@@ -70,11 +70,11 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
             entity.HasNoKey();
             entity.ConfigureCourseEntity();
             entity.HasOne(sa => sa.Assessment)
-                .WithMany(a => a.StudentAssessments)
+                .WithMany()
                 .HasForeignKey(sa => new { sa.IdAssessment, sa.CodeModule, sa.CodePresentation })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(sa => sa.StudentInfo)
-                .WithMany(si => si.Assessments)
+                .WithMany()
                 .HasForeignKey(sa => new { sa.CodeModule, sa.CodePresentation, sa.IdStudent })
                 .OnDelete(DeleteBehavior.Restrict);
         });
@@ -84,11 +84,11 @@ public class OuladContext(DbContextOptions<OuladContext> options) : DbContext(op
             entity.HasNoKey();
             entity.ConfigureCourseEntity();
             entity.HasOne(sv => sv.Vle)
-                .WithMany(v => v.StudentVles)
+                .WithMany()
                 .HasForeignKey(sv => new { sv.IdSite, sv.CodeModule, sv.CodePresentation })
                 .OnDelete(DeleteBehavior.Restrict);
             entity.HasOne(sv => sv.StudentInfo)
-                .WithMany(si => si.StudentVles)
+                .WithMany()
                 .HasForeignKey(sv => new { sv.CodeModule, sv.CodePresentation, sv.IdStudent })
                 .OnDelete(DeleteBehavior.Restrict);
         });

--- a/src/Domain/Assessment.cs
+++ b/src/Domain/Assessment.cs
@@ -25,7 +25,6 @@ public class Assessment : ICourseEntity
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }
 
-    public ICollection<StudentAssessment> StudentAssessments { get; set; } = new List<StudentAssessment>();
 
     [Column(Order = 0, TypeName = "varchar(45)")]
     [MaxLength(45)]

--- a/src/Domain/Course.cs
+++ b/src/Domain/Course.cs
@@ -10,7 +10,6 @@ public class Course : ICourseEntity
 
     public ICollection<StudentInfo> Students { get; set; } = new List<StudentInfo>();
     public ICollection<Assessment> Assessments { get; set; } = new List<Assessment>();
-    public ICollection<StudentRegistration> Registrations { get; set; } = new List<StudentRegistration>();
     public ICollection<Vle> Vles { get; set; } = new List<Vle>();
 
     [Key]

--- a/src/Domain/StudentInfo.cs
+++ b/src/Domain/StudentInfo.cs
@@ -37,10 +37,6 @@ public class StudentInfo : ICourseEntity
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }
 
-    public ICollection<StudentRegistration> Registrations { get; set; } = new List<StudentRegistration>();
-    public ICollection<StudentAssessment> Assessments { get; set; } = new List<StudentAssessment>();
-    public ICollection<StudentVle> StudentVles { get; set; } = new List<StudentVle>();
-
     [Column(Order = 0, TypeName = "varchar(45)")]
     [MaxLength(45)]
     public string CodeModule { get; set; } = null!;

--- a/src/Domain/Vle.cs
+++ b/src/Domain/Vle.cs
@@ -23,7 +23,6 @@ public class Vle : ICourseEntity
     [ForeignKey("CodeModule,CodePresentation")]
     public Course? Course { get; set; }
 
-    public ICollection<StudentVle> StudentVles { get; set; } = new List<StudentVle>();
 
     [Column(Order = 1, TypeName = "varchar(45)")]
     [MaxLength(45)]


### PR DESCRIPTION
## Summary
- remove navigation properties for keyless tables
- drop Ignore calls for removed properties

## Testing
- `./test.sh` *(fails: dotnet SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847a2174b1c832eab53e73e9205d383