### PR TITLE
Implement bar chart and stats utilities

### DIFF
--- a/src/Eda/EdaUtils.cs
+++ b/src/Eda/EdaUtils.cs
@@ -54,6 +54,38 @@ public static class EdaUtils
         return cov / Math.Sqrt(varX * varY);
     }
 
+    public static double Mean(IEnumerable<double> values)
+    {
+        var data = values as double[] ?? values.ToArray();
+        return data.Length == 0 ? 0 : data.Average();
+    }
+
+    public static double StandardDeviation(IEnumerable<double> values)
+    {
+        var data = values as double[] ?? values.ToArray();
+        if (data.Length == 0) return 0;
+        var mean = data.Average();
+        var variance = data.Sum(v => (v - mean) * (v - mean)) / data.Length;
+        return Math.Sqrt(variance);
+    }
+
+    public static double Kurtosis(IEnumerable<double> values)
+    {
+        var data = values as double[] ?? values.ToArray();
+        if (data.Length < 2) return 0;
+        var mean = data.Average();
+        double m2 = 0, m4 = 0;
+        foreach (var v in data)
+        {
+            var d = v - mean;
+            m2 += d * d;
+            m4 += d * d * d * d;
+        }
+        m2 /= data.Length;
+        m4 /= data.Length;
+        return m4 / (m2 * m2) - 3.0;
+    }
+
     public static void AddVerticalLine(this PlotModel model, double x, string text)
     {
         model.Annotations.Add(new LineAnnotation

--- a/tests/EdaTests/ExtendedEdaTests.cs
+++ b/tests/EdaTests/ExtendedEdaTests.cs
@@ -52,11 +52,21 @@ public class ExtendedEdaTests
         var tmp3 = Path.GetTempFileName();
         var tmp4 = Path.GetTempFileName();
         var tmp5 = Path.GetTempFileName();
+        var tmp6 = Path.GetTempFileName();
 
         ExtendedEda.PlotConfusionMatrix(context, tmp1);
         ExtendedEda.PlotCorrelationMatrix(context, tmp2);
         ExtendedEda.PlotBoxplot(context, tmp3);
+        ExtendedEda.PlotBarChart(context, tmp6);
         ExtendedEda.PlotNormalDistribution(context, tmp4);
         ExtendedEda.PlotScatter(context, tmp5);
+    }
+
+    [Fact]
+    public void Statistical_methods_do_not_throw()
+    {
+        using var context = CreateContext();
+        ExtendedEda.PerformTTest(context);
+        ExtendedEda.PerformAnova(context);
     }
 }


### PR DESCRIPTION
## Summary
- add Mean/StdDev/Kurtosis helpers
- implement bar chart of FinalResult by AgeBand
- add t-test and ANOVA utilities
- save results in plots folder when running ExtendedEda
- extend tests for new functions

## Testing
- `./setup.sh` *(fails: ForbiddenUnable to establish SSL connection)*
- `./test.sh` *(fails: dotnet SDK no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684845602d00832e901c41d963e631c1